### PR TITLE
Support for lang selector

### DIFF
--- a/containers/cairo/cairo_container.cpp
+++ b/containers/cairo/cairo_container.cpp
@@ -896,6 +896,12 @@ void cairo_container::get_media_features( litehtml::media_features& media )
 	ReleaseDC(NULL, hdc);
 }
 
+void cairo_container::get_language(tstring& language, tstring & culture) const
+{
+	language = "en";
+	culture = "";
+}
+
 void cairo_container::make_url_utf8( const char* url, const char* basepath, std::wstring& out )
 {
 	wchar_t* urlW = cairo_font::utf8_to_wchar(url);

--- a/containers/cairo/cairo_container.h
+++ b/containers/cairo/cairo_container.h
@@ -81,6 +81,8 @@ public:
 	virtual void						del_clip();
 	virtual litehtml::element*			create_element(const litehtml::tchar_t* tag_name, const litehtml::string_map& attributes, litehtml::document* doc);
 	virtual void						get_media_features(litehtml::media_features& media);
+	virtual void						get_language(tstring& language, tstring & culture);
+
 
 	virtual void						make_url( LPCWSTR url, LPCWSTR basepath, std::wstring& out ) = 0;
 	virtual image_ptr					get_image(LPCWSTR url, bool redraw_on_ready) = 0;

--- a/containers/linux/container_linux.cpp
+++ b/containers/linux/container_linux.cpp
@@ -930,3 +930,9 @@ void container_linux::get_media_features(litehtml::media_features& media)
 	media.color_index	= 256;
 	media.resolution	= 96;
 }
+
+void container_linux::get_language(tstring& language, tstring & culture) const
+{
+	language = "en";
+	culture = "";
+}

--- a/containers/linux/container_linux.h
+++ b/containers/linux/container_linux.h
@@ -66,6 +66,7 @@ public:
 	virtual void 						draw_list_marker(litehtml::uint_ptr hdc, const litehtml::list_marker& marker);
 	virtual litehtml::element*			create_element(const litehtml::tchar_t* tag_name, const litehtml::string_map& attributes, litehtml::document* doc);
 	virtual void						get_media_features(litehtml::media_features& media);
+	virtual void						get_language(tstring& language, tstring & culture);
 
 
 	virtual	void						transform_text(litehtml::tstring& text, litehtml::text_transform tt);

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -594,6 +594,27 @@ bool litehtml::document::media_changed()
 	return false;
 }
 
+bool litehtml::document::lang_changed()
+{
+	if(!m_media_lists.empty())
+	{
+		tstring culture;
+		container()->get_language(m_lang, culture);
+		if(!culture.empty())
+		{
+			m_culture = m_lang + '-' + culture;
+		}
+		else
+		{
+			m_culture.clear();
+		}
+		m_root->refresh_styles();
+		m_root->parse_styles();
+		return true;
+	}
+	return false;
+}
+
 bool litehtml::document::update_media_lists(const media_features& features)
 {
 	bool update_styles = false;

--- a/src/document.h
+++ b/src/document.h
@@ -66,6 +66,8 @@ namespace litehtml
 		element::ptr						m_over_element;
 		elements_vector						m_tabular_elements;
 		media_features						m_media;
+		tstring                             m_lang;
+		tstring                             m_culture;
 	public:
 		document(litehtml::document_container* objContainer, litehtml::context* ctx);
 		virtual ~document();
@@ -90,6 +92,8 @@ namespace litehtml
 		void							add_fixed_box(const position& pos);
 		void							add_media_list(media_query_list::ptr list);
 		bool							media_changed();
+		bool							lang_changed();
+		bool                            match_lang(const tstring & lang);
 		void							add_tabular(element::ptr el);
 
 		static litehtml::document::ptr createFromString(const tchar_t* str, litehtml::document_container* objPainter, litehtml::context* ctx, litehtml::css* user_styles = 0);
@@ -112,5 +116,9 @@ namespace litehtml
 	inline void document::add_tabular(element::ptr el)
 	{
 		m_tabular_elements.push_back(el);
+	}
+	inline bool document::match_lang(const tstring & lang)
+	{
+		return lang == m_lang || lang == m_culture;
 	}
 }

--- a/src/html.h
+++ b/src/html.h
@@ -55,7 +55,9 @@ namespace litehtml
 		virtual void				del_clip() = 0;
 		virtual void				get_client_rect(litehtml::position& client) = 0;
 		virtual litehtml::element*	create_element(const tchar_t* tag_name, const string_map& attributes, litehtml::document* doc) = 0;
-		virtual void				get_media_features(litehtml::media_features& media) = 0;
+
+		virtual void				get_media_features(litehtml::media_features& media) const = 0;
+		virtual void				get_language(tstring& language, tstring & culture) const = 0;
 	};
 
 	void trim(tstring &s);

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -850,6 +850,16 @@ int litehtml::html_tag::select(const css_element_selector& selector, bool apply_
 						}
 					}
 					break;
+				case pseudo_class_lang:
+					{
+						trim( selector_param );
+
+						if( !m_doc->match_lang( selector_param ) )
+						{
+							return select_no_match;
+						}
+					}
+					break;
 				default:
 					if(std::find(m_pseudo_classes.begin(), m_pseudo_classes.end(), i->val) == m_pseudo_classes.end())
 					{

--- a/src/types.h
+++ b/src/types.h
@@ -484,7 +484,7 @@ namespace litehtml
 	};
 
 
-#define pseudo_class_strings		_t("only-child;only-of-type;first-child;first-of-type;last-child;last-of-type;nth-child;nth-of-type;nth-last-child;nth-last-of-type;not")
+#define pseudo_class_strings		_t("only-child;only-of-type;first-child;first-of-type;last-child;last-of-type;nth-child;nth-of-type;nth-last-child;nth-last-of-type;not;lang")
 
 	enum pseudo_class
 	{
@@ -499,6 +499,7 @@ namespace litehtml
 		pseudo_class_nth_last_child,
 		pseudo_class_nth_last_of_type,
 		pseudo_class_not,
+		pseudo_class_lang,
 	};
 
 #define content_property_string		_t("none;normal;open-quote;close-quote;no-open-quote;no-close-quote")


### PR DESCRIPTION
This PR implements support for :lang(en-US) pseudo selector.

Containers need to implement get_language(), setting both lang and culture. 
