### PR TITLE
Fixed the following css selector: .foo:nth-child(1) .bar:after/before

### DIFF
--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -3451,8 +3451,26 @@ void litehtml::html_tag::refresh_styles()
 				{
 					if(select(*usel->m_selector, true))
 					{
-						add_style(usel->m_selector->m_style);
-						usel->m_used = true;
+						if(apply & select_match_with_after)
+						{
+							element* el = get_element_after();
+							if(el)
+							{
+								el->add_style(usel->m_selector->m_style);
+							}
+						} else if(apply & select_match_with_before)
+						{
+							element* el = get_element_before();
+							if(el)
+							{
+								el->add_style(usel->m_selector->m_style);
+							}
+						}
+						else
+						{
+							add_style(usel->m_selector->m_style);
+							usel->m_used = true;
+						}
 					}
 				} else if(apply & select_match_with_after)
 				{

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -123,8 +123,26 @@ void litehtml::html_tag::apply_stylesheet( const litehtml::css& stylesheet )
 				{
 					if(select(*(*sel), true))
 					{
-						add_style((*sel)->m_style);
-						us->m_used = true;
+						if(apply & select_match_with_after)
+						{
+							element* el = get_element_after();
+							if(el)
+							{
+								el->add_style((*sel)->m_style);
+							}
+						} else if(apply & select_match_with_before)
+						{
+							element* el = get_element_before();
+							if(el)
+							{
+								el->add_style((*sel)->m_style);
+							}
+						}
+						else
+						{
+							add_style((*sel)->m_style);
+							us->m_used = true;
+						}
 					}
 				} else if(apply & select_match_with_after)
 				{


### PR DESCRIPTION
When a pseudo selector was used in parent selection, the :after/:before would not be processed correctly