### PR TITLE
Optimize class handling

### DIFF
--- a/src/css_selector.cpp
+++ b/src/css_selector.cpp
@@ -15,6 +15,7 @@ void litehtml::css_element_selector::parse( const tstring& txt )
 
 			tstring::size_type pos = txt.find_first_of(_t(".#[:"), el_end + 1);
 			attribute.val		= txt.substr(el_end + 1, pos - el_end - 1);
+			split_string( attribute.val, attribute.class_val, _t(" ") );
 			attribute.condition	= select_equal;
 			attribute.attribute	= _t("class");
 			m_attrs.push_back(attribute);
@@ -241,9 +242,7 @@ void litehtml::css_selector::calc_specificity()
 		{
 			if(i->attribute == _t("class"))
 			{
-				string_vector tokens;
-				split_string(i->val, tokens, _t(" "));
-				m_specificity.c += (int) tokens.size();
+				m_specificity.c += (int) i->class_val.size();
 			} else
 			{
 				m_specificity.c++;

--- a/src/css_selector.h
+++ b/src/css_selector.h
@@ -141,22 +141,6 @@ namespace litehtml
 		{
 			condition = select_exists;
 		}
-
-		css_attribute_selector(const css_attribute_selector& val)
-		{
-			this->val	= val.val;
-			class_val	= val.class_val;
-			condition	= val.condition;
-			attribute	= val.attribute;
-		}
-
-		css_attribute_selector(css_attribute_selector&& val) /*noexcept*/
-		{
-			this->val	= std::move( val.val );
-			class_val	= std::move( val.class_val );
-			condition	= std::move( val.condition );
-			attribute	= val.attribute;
-		}
 	};
 
 	//////////////////////////////////////////////////////////////////////////
@@ -167,16 +151,6 @@ namespace litehtml
 		tstring							m_tag;
 		css_attribute_selector::vector	m_attrs;
 	public:
-		css_element_selector()
-		{
-
-		}
-
-		css_element_selector(const css_element_selector& val)
-		{
-			m_tag	= val.m_tag;
-			m_attrs	= val.m_attrs;
-		}
 
 		void parse(const tstring& txt);
 	};

--- a/src/css_selector.h
+++ b/src/css_selector.h
@@ -149,6 +149,14 @@ namespace litehtml
 			condition	= val.condition;
 			attribute	= val.attribute;
 		}
+
+		css_attribute_selector(css_attribute_selector&& val) /*noexcept*/
+		{
+			this->val	= std::move( val.val );
+			class_val	= std::move( val.class_val );
+			condition	= std::move( val.condition );
+			attribute	= val.attribute;
+		}
 	};
 
 	//////////////////////////////////////////////////////////////////////////

--- a/src/css_selector.h
+++ b/src/css_selector.h
@@ -134,6 +134,7 @@ namespace litehtml
 
 		tstring					attribute;
 		tstring					val;
+		string_vector			class_val;
 		attr_select_condition	condition;
 
 		css_attribute_selector()
@@ -144,6 +145,7 @@ namespace litehtml
 		css_attribute_selector(const css_attribute_selector& val)
 		{
 			this->val	= val.val;
+			class_val	= val.class_val;
 			condition	= val.condition;
 			attribute	= val.attribute;
 		}

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -334,6 +334,7 @@ const litehtml::tchar_t* litehtml::element::get_cursor()							LITEHTML_RETURN_F
 litehtml::white_space litehtml::element::get_white_space() const					LITEHTML_RETURN_FUNC(white_space_normal)
 litehtml::style_display litehtml::element::get_display() const						LITEHTML_RETURN_FUNC(display_none)
 bool litehtml::element::set_pseudo_class( const tchar_t* pclass, bool add )			LITEHTML_RETURN_FUNC(false)
+bool litehtml::element::set_class( const tchar_t* pclass, bool add )				LITEHTML_RETURN_FUNC(false)
 litehtml::element_position litehtml::element::get_element_position(css_offsets* offsets) const			LITEHTML_RETURN_FUNC(element_position_static)
 bool litehtml::element::is_replaced() const											LITEHTML_RETURN_FUNC(false)
 int litehtml::element::line_height() const											LITEHTML_RETURN_FUNC(0)

--- a/src/element.h
+++ b/src/element.h
@@ -133,6 +133,7 @@ namespace litehtml
 		virtual void				init_font();
 		virtual bool				is_point_inside(int x, int y);
 		virtual bool				set_pseudo_class(const tchar_t* pclass, bool add);
+		virtual bool				set_class(const tchar_t* pclass, bool add);
 		virtual bool				is_replaced() const;
 		virtual int					line_height() const;
 		virtual white_space			get_white_space() const;

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -657,13 +657,12 @@ int litehtml::html_tag::select(const css_element_selector& selector, bool apply_
 				{
 					string_vector tokens1;
 					split_string(attr_value, tokens1, _t(" "));
-					string_vector tokens2;
-					split_string(i->val, tokens2, _t(" "));
+					const string_vector & tokens2 = i->class_val;
 					bool found = true;
-					for(string_vector::iterator str1 = tokens2.begin(); str1 != tokens2.end() && found; str1++)
+					for(string_vector::const_iterator str1 = tokens2.begin(); str1 != tokens2.end() && found; str1++)
 					{
 						bool f = false;
-						for(string_vector::iterator str2 = tokens1.begin(); str2 != tokens1.end() && !f; str2++)
+						for(string_vector::const_iterator str2 = tokens1.begin(); str2 != tokens1.end() && !f; str2++)
 						{
 							if( !t_strcasecmp(str1->c_str(), str2->c_str()) )
 							{

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -2299,6 +2299,43 @@ bool litehtml::html_tag::set_pseudo_class( const tchar_t* pclass, bool add )
 	return ret;
 }
 
+bool litehtml::html_tag::set_class( const tchar_t* pclass, bool add )
+{
+	string_vector tokens;
+	split_string(m_class, tokens, _t(" "));
+
+	if(add)
+	{
+		if(std::find(tokens.begin(), tokens.end(), pclass) == tokens.end())
+		{
+			if(m_class.size() > 0)
+			{
+				m_class += _t(" ");
+			}
+			m_class += pclass;
+		} else
+		{
+			return false;
+		}
+	} else
+	{
+		auto end = std::remove(tokens.begin(), tokens.end(), pclass);
+
+		if(end == tokens.end())
+		{
+			return false;
+		}
+
+		tokens.erase(end, tokens.end());
+
+		join_string(m_class, tokens, _t(" "));
+	}
+
+	set_attr(_t("class"), m_class.c_str());
+
+	return true;
+}
+
 int litehtml::html_tag::line_height() const
 {
 	return m_line_height;

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -2315,11 +2315,11 @@ bool litehtml::html_tag::set_class( const tchar_t* pclass, bool add )
 			{
 				m_class_values.push_back( std::move( _class ) );
 				changed = true;
-			} 
+			}
 		}
 	} else
 	{
-		for( auto & _class : classes )
+		for( const auto & _class : classes )
 		{
 			auto end = std::remove(m_class_values.begin(), m_class_values.end(), _class);
 

--- a/src/html_tag.h
+++ b/src/html_tag.h
@@ -135,6 +135,7 @@ namespace litehtml
 		virtual const tchar_t*		get_cursor();
 		virtual void				init_font();
 		virtual bool				set_pseudo_class(const tchar_t* pclass, bool add);
+		virtual bool				set_class(const tchar_t* pclass, bool add);
 		virtual bool				is_replaced() const;
 		virtual int					line_height() const;
 		virtual white_space			get_white_space() const;

--- a/src/html_tag.h
+++ b/src/html_tag.h
@@ -24,8 +24,7 @@ namespace litehtml
 		typedef litehtml::object_ptr<litehtml::html_tag>	ptr;
 	protected:
 		box::vector				m_boxes;
-		tstring					m_id;
-		tstring					m_class;
+		string_vector			m_class_values;
 		tstring					m_tag;
 		litehtml::style			m_style;
 		string_map				m_attrs;


### PR DESCRIPTION
Animating document is usually done by add and removing classes. 

This PR add a set_class that allows to add and remove classes dynamically on an element.

But doing so raise a performance issue. Classes, stored as a single string, needed to be split for each selector. This split was slow due to both memory allocation and specific-case parsing of split_string.

To solve the issue, the classes are now kept into a vector table, created on set_attr. For compatibility issue, the class string is still stored as is in the attribute table