### PR TITLE
select_all() methods added to element and html_tag

### DIFF
--- a/src/element.cpp
+++ b/src/element.cpp
@@ -265,6 +265,9 @@ litehtml::element* litehtml::element::get_element_by_point( int x, int y, int cl
 litehtml::element* litehtml::element::get_child_by_point( int x, int y, int client_x, int client_y, draw_flag flag, int zindex ) LITEHTML_RETURN_FUNC(0)
 void litehtml::element::get_line_left_right( int y, int def_right, int& ln_left, int& ln_right ) LITEHTML_EMPTY_FUNC
 void litehtml::element::add_style( litehtml::style::ptr st )						LITEHTML_EMPTY_FUNC
+void litehtml::element::select_all(const css_selector& selector, litehtml::elements_vector& res)	LITEHTML_EMPTY_FUNC
+litehtml::elements_vector litehtml::element::select_all(const litehtml::css_selector& selector)	 LITEHTML_RETURN_FUNC(litehtml::elements_vector())
+litehtml::elements_vector litehtml::element::select_all(const litehtml::tstring& selector)			 LITEHTML_RETURN_FUNC(litehtml::elements_vector())
 litehtml::element::ptr litehtml::element::select_one( const css_selector& selector ) LITEHTML_RETURN_FUNC(0)
 litehtml::element::ptr litehtml::element::select_one( const tstring& selector )		LITEHTML_RETURN_FUNC(0)
 litehtml::element* litehtml::element::find_adjacent_sibling( element* el, const css_selector& selector, bool apply_pseudo /*= true*/, bool* is_pseudo /*= 0*/ ) LITEHTML_RETURN_FUNC(0)

--- a/src/element.h
+++ b/src/element.h
@@ -26,6 +26,8 @@ namespace litehtml
 		margins						m_padding;
 		margins						m_borders;
 		bool						m_skip;
+		
+		virtual void select_all(const css_selector& selector, elements_vector& res);
 	public:
 		element(litehtml::document* doc);
 		virtual ~element();
@@ -81,6 +83,9 @@ namespace litehtml
 		int							calc_width(int defVal) const;
 		int							get_inline_shift_left();
 		int							get_inline_shift_right();
+
+		virtual elements_vector		select_all(const tstring& selector);
+		virtual elements_vector		select_all(const css_selector& selector);
 
 		virtual element::ptr		select_one(const tstring& selector);
 		virtual element::ptr		select_one(const css_selector& selector);

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -78,6 +78,35 @@ const litehtml::tchar_t* litehtml::html_tag::get_attr( const tchar_t* name, cons
 	return def;
 }
 
+litehtml::elements_vector litehtml::html_tag::select_all( const tstring& selector )
+{
+	css_selector sel(media_query_list::ptr(0));
+	sel.parse(selector);
+	
+	return select_all(sel);
+}
+
+litehtml::elements_vector litehtml::html_tag::select_all( const css_selector& selector )
+{
+	litehtml::elements_vector res;
+	select_all(selector, res);
+	return res;
+}
+
+void litehtml::html_tag::select_all(const css_selector& selector, elements_vector& res)
+{
+	if(select(selector))
+	{
+		res.push_back(this);
+	}
+	
+	for(elements_vector::iterator el = m_children.begin(); el != m_children.end(); el++)
+	{
+		(*el)->select_all(selector, res);
+	}
+}
+
+
 litehtml::element::ptr litehtml::html_tag::select_one( const tstring& selector )
 {
 	css_selector sel(media_query_list::ptr(0));

--- a/src/html_tag.h
+++ b/src/html_tag.h
@@ -79,6 +79,8 @@ namespace litehtml
 		int						m_border_spacing_y;
 		border_collapse			m_border_collapse;
 
+		virtual void			select_all(const css_selector& selector, elements_vector& res);
+
 	public:
 		html_tag(litehtml::document* doc);
 		virtual ~html_tag();
@@ -154,6 +156,9 @@ namespace litehtml
 
 		virtual int					select(const css_selector& selector, bool apply_pseudo = true);
 		virtual int					select(const css_element_selector& selector, bool apply_pseudo = true);
+
+		virtual elements_vector		select_all(const tstring& selector);
+		virtual elements_vector		select_all(const css_selector& selector);
 
 		virtual element::ptr		select_one(const tstring& selector);
 		virtual element::ptr		select_one(const css_selector& selector);


### PR DESCRIPTION
There are brilliant <code>select_one</code> methods in each html element for searching the tree. But they are useless when you want to list <em>all</em> the items for a CSS selector, not just the <em>first</em> one. So I've made <code>select_all()</code> methods for that. They return <code>elements_vector</code> and work recursively (just as <code>select_one</code>-s do).

Do you agree they are useful? I've tested them a bit already.