### PR TITLE
Added removeChild and clearRecursive

### DIFF
--- a/src/element.cpp
+++ b/src/element.cpp
@@ -313,6 +313,8 @@ void litehtml::element::get_content_size( size& sz, int max_width )					LITEHTML
 void litehtml::element::init()														LITEHTML_EMPTY_FUNC
 int litehtml::element::render( int x, int y, int max_width, bool second_pass )		LITEHTML_RETURN_FUNC(0)
 bool litehtml::element::appendChild( litehtml::element* el )						LITEHTML_RETURN_FUNC(false)
+bool litehtml::element::removeChild( litehtml::element* el )						LITEHTML_RETURN_FUNC(false)
+void litehtml::element::clearRecursive()											LITEHTML_EMPTY_FUNC
 const litehtml::tchar_t* litehtml::element::get_tagName() const						LITEHTML_RETURN_FUNC(_t(""))
 void litehtml::element::set_tagName( const tchar_t* tag )							LITEHTML_EMPTY_FUNC
 void litehtml::element::set_data( const tchar_t* data )								LITEHTML_EMPTY_FUNC

--- a/src/element.h
+++ b/src/element.h
@@ -100,6 +100,8 @@ namespace litehtml
 		virtual void				render_positioned(render_type rt = render_all);
 
 		virtual bool				appendChild(litehtml::element* el);
+		virtual bool				removeChild(litehtml::element* el);
+		virtual void				clearRecursive();
 
 		virtual const tchar_t*		get_tagName() const;
 		virtual void				set_tagName(const tchar_t* tag);

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -49,6 +49,28 @@ bool litehtml::html_tag::appendChild( litehtml::element* el )
 	return false;
 }
 
+bool litehtml::html_tag::removeChild( litehtml::element* el )
+{
+	if(el && el->parent() == this)
+	{
+		el->parent(NULL);
+		m_children.erase(std::remove(m_children.begin(), m_children.end(), el), m_children.end());
+		return true;
+	}
+	return false;
+}
+
+void litehtml::html_tag::clearRecursive()
+{
+	for(elements_vector::iterator iter = m_children.begin(); iter != m_children.end(); iter++)
+	{
+		(*iter)->clearRecursive();
+		(*iter)->parent(NULL);
+	}
+	m_children.clear();
+}
+
+
 const litehtml::tchar_t* litehtml::html_tag::get_tagName() const
 {
 	return m_tag.c_str();

--- a/src/html_tag.h
+++ b/src/html_tag.h
@@ -99,6 +99,8 @@ namespace litehtml
 		int							finish_last_box(bool end_of_render = false);
 
 		virtual bool				appendChild(litehtml::element* el);
+		virtual bool				removeChild(litehtml::element* el);
+		virtual void				clearRecursive();
 		virtual const tchar_t*		get_tagName() const;
 		virtual void				set_tagName(const tchar_t* tag);
 		virtual void				set_data(const tchar_t* data);


### PR DESCRIPTION
I've added 2 methods: 
1. <code>removeChild</code> is symmetrical to <code>appendChild</code> - it removes the item from children and clears its parent.
2. <code>clearRecursive</code> removes all children (and disconnect their parents) from the element recursively.

Both methods are very useful for dynamic DOM manipulation.

In addition I would recommend to reconsider:
1. <code>children()</code> method that returns plain list - the modification of this list could lead to an inconsistent structure (for example if someone adds an item to it without setting parent of the item), so maybe it should be a constant method returning constant link? (all manipulations would be made with additional methods)
2. Maybe <code>elements_vector</code> should be changed from <code>std::vector</code> to <code>std::list</code> - there are many use cases that add, iterate or remove items from it, but I see no cases that uses items indexes. Adding (or removing) to the middle of a vector is not quite a cheap thing...

What do you think about my ideas?
