### PR TITLE
Added scroll offset values

### DIFF
--- a/src/element.cpp
+++ b/src/element.cpp
@@ -315,6 +315,7 @@ int litehtml::element::render( int x, int y, int max_width, bool second_pass )		
 bool litehtml::element::appendChild( litehtml::element* el )						LITEHTML_RETURN_FUNC(false)
 bool litehtml::element::removeChild( litehtml::element* el )						LITEHTML_RETURN_FUNC(false)
 void litehtml::element::clearRecursive()											LITEHTML_EMPTY_FUNC
+void litehtml::element::set_scroll_offset(int x, int y)								LITEHTML_EMPTY_FUNC
 const litehtml::tchar_t* litehtml::element::get_tagName() const						LITEHTML_RETURN_FUNC(_t(""))
 void litehtml::element::set_tagName( const tchar_t* tag )							LITEHTML_EMPTY_FUNC
 void litehtml::element::set_data( const tchar_t* data )								LITEHTML_EMPTY_FUNC

--- a/src/element.h
+++ b/src/element.h
@@ -102,6 +102,7 @@ namespace litehtml
 		virtual bool				appendChild(litehtml::element* el);
 		virtual bool				removeChild(litehtml::element* el);
 		virtual void				clearRecursive();
+		virtual void				set_scroll_offset(int x, int y);
 
 		virtual const tchar_t*		get_tagName() const;
 		virtual void				set_tagName(const tchar_t* tag);

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -31,6 +31,8 @@ litehtml::html_tag::html_tag(litehtml::document* doc) : litehtml::element(doc)
 	m_border_spacing_x		= 0;
 	m_border_spacing_y		= 0;
 	m_border_collapse		= border_collapse_separate;
+	m_offset_x				= 0;
+	m_offset_y				= 0;
 }
 
 litehtml::html_tag::~html_tag()
@@ -2353,6 +2355,9 @@ int litehtml::html_tag::place_element( element* el, int max_width )
 		}
 		break;
 	}
+
+	el->m_pos.x -= m_offset_x;
+	el->m_pos.y -= m_offset_y;
 
 	return ret_width;
 }

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -31,8 +31,8 @@ litehtml::html_tag::html_tag(litehtml::document* doc) : litehtml::element(doc)
 	m_border_spacing_x		= 0;
 	m_border_spacing_y		= 0;
 	m_border_collapse		= border_collapse_separate;
-	m_offset_x				= 0;
-	m_offset_y				= 0;
+	m_scroll_offset_x		= 0;
+	m_scroll_offset_y		= 0;
 }
 
 litehtml::html_tag::~html_tag()
@@ -2356,8 +2356,8 @@ int litehtml::html_tag::place_element( element* el, int max_width )
 		break;
 	}
 
-	el->m_pos.x -= m_offset_x;
-	el->m_pos.y -= m_offset_y;
+	el->m_pos.x -= m_scroll_offset_x;
+	el->m_pos.y -= m_scroll_offset_y;
 
 	return ret_width;
 }

--- a/src/html_tag.h
+++ b/src/html_tag.h
@@ -77,8 +77,9 @@ namespace litehtml
 		int						m_border_spacing_x;
 		int						m_border_spacing_y;
 
-		int						m_offset_x;
-		int						m_offset_y;
+		int							m_scroll_offset_x;
+		int							m_scroll_offset_y;
+
 		border_collapse			m_border_collapse;
 
 		virtual void			select_all(const css_selector& selector, elements_vector& res);
@@ -97,7 +98,7 @@ namespace litehtml
 		virtual void				render_positioned(render_type rt = render_all);
 
 		int							new_box( element* el, int max_width );
-		void						set_offset(int x, int y) { m_offset_x = x; m_offset_y = y; }
+		void						set_offset(int x, int y) { m_scroll_offset_x = x; m_scroll_offset_y = y; }
 
 		int							get_cleared_top( element* el, int line_top );
 		int							finish_last_box(bool end_of_render = false);

--- a/src/html_tag.h
+++ b/src/html_tag.h
@@ -76,6 +76,9 @@ namespace litehtml
 		css_length				m_css_border_spacing_y;
 		int						m_border_spacing_x;
 		int						m_border_spacing_y;
+
+		int						m_offset_x;
+		int						m_offset_y;
 		border_collapse			m_border_collapse;
 
 		virtual void			select_all(const css_selector& selector, elements_vector& res);
@@ -94,6 +97,7 @@ namespace litehtml
 		virtual void				render_positioned(render_type rt = render_all);
 
 		int							new_box( element* el, int max_width );
+		void						set_offset(int x, int y) { m_offset_x = x; m_offset_y = y; }
 
 		int							get_cleared_top( element* el, int line_top );
 		int							finish_last_box(bool end_of_render = false);


### PR DESCRIPTION
I've done some research about scrolling in html/css. And I found no default mechanism (without JS) to set a scroll position. No HTML attributes, no CSS attributes. Thus I made a small modification that lets the user to move contents of an element horizontally and vertically in order to implement scrollbars (or any other scrolling technique. This feature is outside of HTML/CSS specs, so it's implemented as two special fields in the element class.
I'm not sure that I added the changes to a proper place - I'm not an expert in your code. If I misplaces them, please, let me know and I'll fix it. The main target is to move all the contents of an element without any additional performance loss.

An additional question concerning this problem: how to calculate maximum offsets? I mean - I want to know the "virtual size" of an element's contents. Can I calculate the limits during the rendering process (and how) and save them somewhere?