### PR TITLE
Over element getter

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -95,7 +95,7 @@ namespace litehtml
 		bool							lang_changed();
 		bool                            match_lang(const tstring & lang);
 		void							add_tabular(const element::ptr& el);
-		const element::ptr				get_over_element() const { return m_over_element; }
+		const element::const_ptr		get_over_element() const { return m_over_element; }
 
 		static litehtml::document::ptr createFromString(const tchar_t* str, litehtml::document_container* objPainter, litehtml::context* ctx, litehtml::css* user_styles = 0);
 		static litehtml::document::ptr createFromUTF8(const char* str, litehtml::document_container* objPainter, litehtml::context* ctx, litehtml::css* user_styles = 0);

--- a/src/document.h
+++ b/src/document.h
@@ -95,6 +95,7 @@ namespace litehtml
 		bool							lang_changed();
 		bool                            match_lang(const tstring & lang);
 		void							add_tabular(const element::ptr& el);
+		const element::ptr				get_over_element() const { return m_over_element; }
 
 		static litehtml::document::ptr createFromString(const tchar_t* str, litehtml::document_container* objPainter, litehtml::context* ctx, litehtml::css* user_styles = 0);
 		static litehtml::document::ptr createFromUTF8(const char* str, litehtml::document_container* objPainter, litehtml::context* ctx, litehtml::css* user_styles = 0);

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -376,7 +376,7 @@ void litehtml::element::on_click()													LITEHTML_EMPTY_FUNC
 void litehtml::element::init_font()													LITEHTML_EMPTY_FUNC
 void litehtml::element::get_inline_boxes( position::vector& boxes )					LITEHTML_EMPTY_FUNC
 void litehtml::element::parse_styles( bool is_reparse /*= false*/ )					LITEHTML_EMPTY_FUNC
-const litehtml::tchar_t* litehtml::element::get_attr( const tchar_t* name, const tchar_t* def /*= 0*/ )	LITEHTML_RETURN_FUNC(def)
+const litehtml::tchar_t* litehtml::element::get_attr( const tchar_t* name, const tchar_t* def /*= 0*/ ) const LITEHTML_RETURN_FUNC(def)
 bool litehtml::element::is_white_space() const										LITEHTML_RETURN_FUNC(false)
 bool litehtml::element::is_body() const												LITEHTML_RETURN_FUNC(false)
 bool litehtml::element::is_break() const											LITEHTML_RETURN_FUNC(false)

--- a/src/element.h
+++ b/src/element.h
@@ -129,7 +129,7 @@ namespace litehtml
 		virtual css_length			get_css_height() const;
 
 		virtual void				set_attr(const tchar_t* name, const tchar_t* val);
-		virtual const tchar_t*		get_attr(const tchar_t* name, const tchar_t* def = 0);
+		virtual const tchar_t*		get_attr(const tchar_t* name, const tchar_t* def = 0) const;
 		virtual void				apply_stylesheet(const litehtml::css& stylesheet);
 		virtual void				refresh_styles();
 		virtual bool				is_white_space() const;

--- a/src/element.h
+++ b/src/element.h
@@ -15,8 +15,9 @@ namespace litehtml
 		friend class el_table;
 		friend class document;
 	public:
-		typedef std::shared_ptr<litehtml::element>		ptr;
-		typedef std::weak_ptr<litehtml::element>		weak_ptr;
+		typedef std::shared_ptr<litehtml::element>			ptr;
+		typedef std::shared_ptr<const litehtml::element>	const_ptr;
+		typedef std::weak_ptr<litehtml::element>			weak_ptr;
 	protected:
 		std::weak_ptr<element>		m_parent;
 		std::weak_ptr<litehtml::document>	m_doc;

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -96,7 +96,7 @@ void litehtml::html_tag::set_attr( const tchar_t* name, const tchar_t* val )
 	}
 }
 
-const litehtml::tchar_t* litehtml::html_tag::get_attr( const tchar_t* name, const tchar_t* def )
+const litehtml::tchar_t* litehtml::html_tag::get_attr( const tchar_t* name, const tchar_t* def ) const
 {
 	string_map::const_iterator attr = m_attrs.find(name);
 	if(attr != m_attrs.end())

--- a/src/html_tag.h
+++ b/src/html_tag.h
@@ -137,7 +137,7 @@ namespace litehtml
 		virtual overflow			get_overflow() const override;
 
 		virtual void				set_attr(const tchar_t* name, const tchar_t* val) override;
-		virtual const tchar_t*		get_attr(const tchar_t* name, const tchar_t* def = 0) override;
+		virtual const tchar_t*		get_attr(const tchar_t* name, const tchar_t* def = 0) const override;
 		virtual void				apply_stylesheet(const litehtml::css& stylesheet) override;
 		virtual void				refresh_styles() override;
 


### PR DESCRIPTION
element has not yet got a getter for its private m_over_element, which is set on mouse over.

This makes it impossible for outside code to implement a status bar with the link target, because the link target is not accessible.

So I implemented:
- a shared pointer to a const element - to be safe when getting the over element
- made get_attr const - otherwise the hoverered element type is not determinable const. Since this is a getter, it is best to make it const anyway.
- the get_over_element() getter, which returns a const shared pointer to the currently hovered element
