### PR TITLE
On windows add gumbo as an include directory (to find strings.h)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,3 +60,7 @@ set(SOURCE_GUMBO    src/gumbo/attribute.c
 
 add_library(litehtml STATIC ${SOURCE_LITEHTML} ${SOURCE_GUMBO})
 
+if(WIN32)
+     target_include_directories(litehtml PUBLIC src/gumbo)
+endif()
+


### PR DESCRIPTION
This does fix issue #43 