### PR TITLE
Do not overwrite default compilation in msvc with unknown options!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,12 @@ cmake_minimum_required(VERSION 2.8)
 
 project(litehtml)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-std=c++11 -O0 -DDEBUG -g")
-set(CMAKE_C_FLAGS_DEBUG "-std=c99 -O0 -DDEBUG -g")
-set(CMAKE_CXX_FLAGS_RELEASE "-std=c++11 -O3")
-set(CMAKE_C_FLAGS_RELEASE "-std=c99 -O3")
+if(NOT MSVC)
+	set(CMAKE_CXX_FLAGS_DEBUG "-std=c++11 -O0 -DDEBUG -g")
+	set(CMAKE_C_FLAGS_DEBUG "-std=c99 -O0 -DDEBUG -g")
+	set(CMAKE_CXX_FLAGS_RELEASE "-std=c++11 -O3")
+	set(CMAKE_C_FLAGS_RELEASE "-std=c99 -O3")
+endif()
 
 set(SOURCE_LITEHTML src/background.cpp
                     src/box.cpp


### PR DESCRIPTION
Those options aren't known by Microsoft Visual Studio and cause trouble, because the default options get lost. A better way to set the C++ or C standard would be the property CXX_STANDARD and C_STANDARD, which are available from cmake 3.1 upwards. 