### PR TITLE
CMAKE Use -std=c++11 for all configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,10 @@ cmake_minimum_required(VERSION 2.8)
 project(litehtml)
 
 if(NOT MSVC)
-	set(CMAKE_CXX_FLAGS_DEBUG "-std=c++11 -O0 -DDEBUG -g")
+	set(CMAKE_CXX_FLAGS "-std=c++11")
+	set(CMAKE_CXX_FLAGS_DEBUG "-O0 -DDEBUG -g")
 	set(CMAKE_C_FLAGS_DEBUG "-std=c99 -O0 -DDEBUG -g")
-	set(CMAKE_CXX_FLAGS_RELEASE "-std=c++11 -O3")
+	set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 	set(CMAKE_C_FLAGS_RELEASE "-std=c99 -O3")
 endif()
 


### PR DESCRIPTION
While trying to build litehtml on my Mac I have noticed that the previous configurations did not apply the -std=c++11 by default which caused the build to fail

With this patch, it will at least always compile