### PR TITLE
Inline boxes background drawing fix

### DIFF
--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -2068,66 +2068,31 @@ void litehtml::html_tag::draw_background( uint_ptr hdc, int x, int y, const posi
 		position::vector boxes;
 		get_inline_boxes(boxes);
 
-		background_paint bg_paint;
-		position content_box;
+		if (!boxes.empty())
+        {
+            position box = boxes.back(); // only last box needed
+		    background_paint bg_paint;
+		    position content_box;
 
-		for(position::vector::iterator box = boxes.begin(); box != boxes.end(); box++)
-		{
-			box->x	+= x;
-			box->y	+= y;
+			box.x += x;
+			box.y += y;
 
-			if(box->does_intersect(clip))
+			if(box.does_intersect(clip))
 			{
-				content_box = *box;
+				content_box = box;
 				content_box -= m_borders;
 				content_box -= m_padding;
 
 				if(bg)
 				{
-					init_background_paint(content_box, bg_paint, bg);
-				}
-
-				css_borders bdr;
-
-				// set left borders radius for the first box
-				if(box == boxes.begin())
-				{
-					bdr.radius.bottom_left_x	= m_css_borders.radius.bottom_left_x;
-					bdr.radius.bottom_left_y	= m_css_borders.radius.bottom_left_y;
-					bdr.radius.top_left_x		= m_css_borders.radius.top_left_x;
-					bdr.radius.top_left_y		= m_css_borders.radius.top_left_y;
-				}
-
-				// set right borders radius for the last box
-				if(box == boxes.end() - 1)
-				{
-					bdr.radius.bottom_right_x	= m_css_borders.radius.bottom_right_x;
-					bdr.radius.bottom_right_y	= m_css_borders.radius.bottom_right_y;
-					bdr.radius.top_right_x		= m_css_borders.radius.top_right_x;
-					bdr.radius.top_right_y		= m_css_borders.radius.top_right_y;
-				}
-
-				
-				bdr.top		= m_css_borders.top;
-				bdr.bottom	= m_css_borders.bottom;
-				if(box == boxes.begin())
-				{
-					bdr.left	= m_css_borders.left;
-				}
-				if(box == boxes.end() - 1)
-				{
-					bdr.right	= m_css_borders.right;
-				}
-
-
-				if(bg)
-				{
-					bg_paint.border_radius = bdr.radius.calc_percents(bg_paint.border_box.width, bg_paint.border_box.width);
+                    init_background_paint(content_box, bg_paint, bg);
+                    bg_paint.border_radius = m_css_borders.radius.calc_percents(bg_paint.border_box.width, bg_paint.border_box.width);
 					get_document()->container()->draw_background(hdc, bg_paint);
 				}
-				borders b = bdr;
-				b.radius = bdr.radius.calc_percents(box->width, box->height);
-				get_document()->container()->draw_borders(hdc, b, *box, false);
+
+                borders brd = m_css_borders;
+                brd.radius = m_css_borders.radius.calc_percents(box.width, box.height);
+                get_document()->container()->draw_borders(hdc, brd, box, false);
 			}
 		}
 	}

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -2069,10 +2069,10 @@ void litehtml::html_tag::draw_background( uint_ptr hdc, int x, int y, const posi
 		get_inline_boxes(boxes);
 
 		if (!boxes.empty())
-        {
-            position box = boxes.back(); // only last box needed
-		    background_paint bg_paint;
-		    position content_box;
+		{
+			position box = boxes.back(); // only last box needed
+			background_paint bg_paint;
+			position content_box;
 
 			box.x += x;
 			box.y += y;
@@ -2085,14 +2085,14 @@ void litehtml::html_tag::draw_background( uint_ptr hdc, int x, int y, const posi
 
 				if(bg)
 				{
-                    init_background_paint(content_box, bg_paint, bg);
-                    bg_paint.border_radius = m_css_borders.radius.calc_percents(bg_paint.border_box.width, bg_paint.border_box.width);
+					init_background_paint(content_box, bg_paint, bg);
+					bg_paint.border_radius = m_css_borders.radius.calc_percents(bg_paint.border_box.width, bg_paint.border_box.width);
 					get_document()->container()->draw_background(hdc, bg_paint);
 				}
 
-                borders brd = m_css_borders;
-                brd.radius = m_css_borders.radius.calc_percents(box.width, box.height);
-                get_document()->container()->draw_borders(hdc, brd, box, false);
+				borders brd = m_css_borders;
+				brd.radius = m_css_borders.radius.calc_percents(box.width, box.height);
+				get_document()->container()->draw_borders(hdc, brd, box, false);
 			}
 		}
 	}


### PR DESCRIPTION
Inline boxes background drawing fix. On the page http://wotblitz.eu/en/news/blitz-client/specials/special-st-patricks-2016/ gold image was drawn twice: 
![gold_drawing_problem](https://cloud.githubusercontent.com/assets/7581547/14110293/78ef6f36-f5ce-11e5-8d09-355be3a2fad7.png)
