### PR TITLE
Add install target and export for use with find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,16 +43,77 @@ set(SOURCE_LITEHTML
     src/web_color.cpp
 )
 
+set(HEADER_LITEHTML
+    include/litehtml.h
+    src/attributes.h
+    src/background.h
+    src/borders.h
+    src/box.h
+    src/context.h
+    src/css_length.h
+    src/css_margins.h
+    src/css_offsets.h
+    src/css_position.h
+    src/css_selector.h
+    src/document.h
+    src/el_anchor.h
+    src/el_base.h
+    src/el_before_after.h
+    src/el_body.h
+    src/el_break.h
+    src/el_cdata.h
+    src/el_comment.h
+    src/el_div.h
+    src/el_font.h
+    src/el_image.h
+    src/el_link.h
+    src/el_para.h
+    src/el_script.h
+    src/el_space.h
+    src/el_style.h
+    src/el_table.h
+    src/el_td.h
+    src/el_text.h
+    src/el_title.h
+    src/el_tr.h
+    src/element.h
+    src/html.h
+    src/html_tag.h
+    src/iterators.h
+    src/media_query.h
+    src/os_types.h
+    src/style.h
+    src/stylesheet.h
+    src/table.h
+    src/types.h
+    src/utf8_strings.h
+    src/web_color.h
+)
+
 add_library(${PROJECT_NAME} ${SOURCE_LITEHTML})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 11
     C_STANDARD 99
+    PUBLIC_HEADER "${HEADER_LITEHTML}"
 )
 
 # Export litehtml includes.
-target_include_directories(${PROJECT_NAME} PUBLIC src)
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
 
 # Gumbo
 target_link_libraries(${PROJECT_NAME} PUBLIC gumbo)
+
+# install and export
+install(TARGETS ${PROJECT_NAME}
+    EXPORT litehtmlTargets
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include/litehtml
+)
+install(FILES cmake/litehtmlConfig.cmake DESTINATION lib/cmake/litehtml)
+install(EXPORT litehtmlTargets FILE litehtmlTargets.cmake DESTINATION lib/cmake/litehtml)
+

--- a/cmake/litehtmlConfig.cmake
+++ b/cmake/litehtmlConfig.cmake
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+find_dependency(gumbo)
+include(${CMAKE_CURRENT_LIST_DIR}/litehtmlTargets.cmake)

--- a/src/gumbo/CMakeLists.txt
+++ b/src/gumbo/CMakeLists.txt
@@ -16,10 +16,32 @@ set(SOURCE_GUMBO
     vector.c
 )
 
+set(HEADER_GUMBO
+    attribute.h
+    char_ref.h
+    error.h
+    gumbo.h
+    insertion_mode.h
+    parser.h
+    string_buffer.h
+    string_piece.h
+    tag_enum.h
+    tag_gperf.h
+    tag_sizes.h
+    tag_strings.h
+    token_type.h
+    tokenizer.h
+    tokenizer_states.h
+    utf8.h
+    util.h
+    vector.h
+)
+
 add_library(${PROJECT_NAME} ${SOURCE_GUMBO})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     C_STANDARD 99
+    PUBLIC_HEADER "${HEADER_GUMBO}"
 )
 
 if(MSVC)
@@ -27,4 +49,15 @@ if(MSVC)
 endif()
 
 # Export gumbo includes.
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR})
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+# install and export
+install(TARGETS ${PROJECT_NAME}
+    EXPORT gumbo
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include/gumbo
+)
+install(EXPORT gumbo FILE gumboConfig.cmake DESTINATION lib/cmake/gumbo)


### PR DESCRIPTION
Installing litehtml now installs the static library,
headers, and CMake configuration files.
So other projects can find and use litehtml with
find_package(litehtml)
when they add the litehtml installation path to CMAKE_PREFIX_PATH