### PR TITLE
Use C++11's std::uint_ptr as litehtml::uint_ptr

### DIFF
--- a/src/os_types.h
+++ b/src/os_types.h
@@ -60,7 +60,7 @@ namespace litehtml
 
 	typedef std::string			tstring;
 	typedef char				tchar_t;
-	typedef void*				uint_ptr;
+	typedef std::uintptr_t			uint_ptr;
 	typedef std::stringstream	tstringstream;
 
 	#define _t(quote)			quote


### PR DESCRIPTION
void* causes linker errors with MinGW on Windows.