### PR TITLE
Avoid compiler warning

### DIFF
--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -4157,11 +4157,12 @@ int litehtml::html_tag::render_box(int x, int y, int max_width, bool second_pass
 	if (ret_width < max_width && !second_pass && have_parent())
 	{
 		if (m_display == display_inline_block ||
-			m_css_width.is_predefined() &&
+			(m_css_width.is_predefined() &&
 			(m_float != float_none ||
 			m_display == display_table ||
 			m_el_position == element_position_absolute ||
 			m_el_position == element_position_fixed
+			)
 			)
 			)
 		{


### PR DESCRIPTION
warning: '&&' within '||' [-Wlogical-op-parentheses]