### PR TITLE
selection: initial implementation for text selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,22 +135,22 @@ install(TARGETS ${PROJECT_NAME}
 install(FILES cmake/litehtmlConfig.cmake DESTINATION lib/cmake/litehtml)
 install(EXPORT litehtmlTargets FILE litehtmlTargets.cmake DESTINATION lib/cmake/litehtml)
 
-# Binary Master.css
-if (WIN32)
-    find_program(XXD_COMMAND xxd.exe ${CMAKE_CURRENT_SOURCE_DIR}/tool)
-    file(TO_NATIVE_PATH ${XXD_COMMAND} XXD_COMMAND)
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include/master.css MASTER_FILE)
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc
-        COMMAND type ${MASTER_FILE} | "${XXD_COMMAND}" -i > ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc)
-else()
-    find_program(XXD_COMMAND xxd)
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc
-        COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/include/master.css | xxd -i > ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc)
-endif()
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc PROPERTIES GENERATED TRUE)
-
 # Tests
 if (BUILD_TESTING)
+    # Binary Master.css
+    if (WIN32)
+        find_program(XXD_COMMAND xxd.exe ${CMAKE_CURRENT_SOURCE_DIR}/tool)
+        file(TO_NATIVE_PATH ${XXD_COMMAND} XXD_COMMAND)
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include/master.css MASTER_FILE)
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc
+            COMMAND type ${MASTER_FILE} | "${XXD_COMMAND}" -i > ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc)
+    else()
+        find_program(XXD_COMMAND xxd)
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc
+            COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/include/master.css | xxd -i > ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc)
+    endif()
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc PROPERTIES GENERATED TRUE)
+
     set(TEST_NAME ${PROJECT_NAME}_tests)
     add_executable(${TEST_NAME} ${TEST_LITEHTML} ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc)
     set_target_properties(${TEST_NAME} PROPERTIES


### PR DESCRIPTION
Initial implementation for selection handling class, raised in #66 

Still to do:
- [x] Improve selection active status management. For example, stop the selection from being active on button mouse up or on mouse leave
- [ ] Move pango implementation to its own container
- [ ] Return range of elements covered by the selection
- [ ] Implement rendering for selection box
- [ ] Implement method which returns the selected text
