### PR TITLE
Fix build with MSVC 2019 and CMake

### DIFF
--- a/include/litehtml/os_types.h
+++ b/include/litehtml/os_types.h
@@ -3,7 +3,7 @@
 
 namespace litehtml
 {
-#if defined( WIN32 ) || defined( WINCE )
+#if defined( WIN32 ) || defined( _WIN32 ) || defined( WINCE )
 
 #ifndef LITEHTML_UTF8
 


### PR DESCRIPTION
The WIN32 define is missing with MSVC 2019, use _WIN32