### PR TITLE
Fixed bug in Cairo CSS font handling and VS2016 build issues

### DIFF
--- a/containers/cairo/cairo_container.cpp
+++ b/containers/cairo/cairo_container.cpp
@@ -40,11 +40,11 @@ litehtml::uint_ptr cairo_container::create_font( const litehtml::tchar_t* faceNa
 		delete f;
 #else
 		fnt_name = fonts[0];
-		if (fnt_name.front() == '"')
+		if (fnt_name.front() == '"' || fnt_name.front() == '\'')
 		{
 			fnt_name.erase(0, 1);
 		}
-		if (fnt_name.back() == '"')
+		if (fnt_name.back() == '"' || fnt_name.back() == '\'')
 		{
 			fnt_name.erase(fnt_name.length() - 1, 1);
 		}

--- a/containers/cairo/cairo_container.h
+++ b/containers/cairo/cairo_container.h
@@ -7,8 +7,8 @@
 #include <tchar.h>
 #include <mlang.h>
 #include <vector>
-#include <cairo.h>
-#include <cairo-win32.h>
+#include "cairo.h"
+#include "cairo-win32.h"
 #include <litehtml.h>
 #include <dib.h>
 #include <txdib.h>

--- a/litehtml.vcxproj
+++ b/litehtml.vcxproj
@@ -42,46 +42,46 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-UTF8|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-UTF8|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-UTF8|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-UTF8|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
It's legit CSS to do this:

    font-family: 'Cascadia Code', Monaco

But `cairo_container` was coded to only support this:

    font-family: "Cascadia Code", Monaco

This change addresses this. 

There's also another fix for building with VS2019 in there. I know it should have been separate but I forgot about it and don't know how to split apart pull requests yet. Sorry.