### PR TITLE
Fix CMake build on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCE_LITEHTML
     src/el_font.cpp
     src/el_image.cpp
     src/el_link.cpp
+    src/el_li.cpp
     src/el_para.cpp
     src/el_script.cpp
     src/el_space.cpp


### PR DESCRIPTION
Building litehtml on Linux using CMake failed with the following error:

```
[ 85%] Linking CXX executable litehtml_tests
liblitehtml.a(document.cpp.o): In function `void __gnu_cxx::new_allocator<litehtml::el_li>::construct<litehtml::el_li, std::shared_ptr<litehtml::document>&>(litehtml::el_li*, std::shared_ptr<litehtml::document>&)':
document.cpp:(.text._ZN9__gnu_cxx13new_allocatorIN8litehtml5el_liEE9constructIS2_JRSt10shared_ptrINS1_8documentEEEEEvPT_DpOT0_[_ZN9__gnu_cxx13new_allocatorIN8litehtml5el_liEE9constructIS2_JRSt10shared_ptrINS1_8documentEEEEEvPT_DpOT0_]+0x48): undefined reference to `litehtml::el_li::el_li(std::shared_ptr<litehtml::document> const&)'
collect2: error: ld returned 1 exit status
```

Adding src/el_li.cpp to the CMakeLists.txt file fixes this error and allows the build to complete successfully. 