### PR TITLE
Increase minimum CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(litehtml CXX)
 include(CTest)

--- a/src/gumbo/CMakeLists.txt
+++ b/src/gumbo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(gumbo C)
 


### PR DESCRIPTION
CMake 3.19 starts warning:
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

CMake 3.5 is already a very low minimum requirement.