### PR TITLE
Build fix for MSVC 2019

### DIFF
--- a/src/num_cvt.cpp
+++ b/src/num_cvt.cpp
@@ -56,7 +56,7 @@ litehtml::tstring litehtml::num_cvt::to_greek_lower(int val)
 
 litehtml::tstring litehtml::num_cvt::to_roman_lower(int value)
 {
-	struct romandata_t { int value; litehtml::tchar_t* numeral; };
+	struct romandata_t { int value; const litehtml::tchar_t* numeral; };
 	const struct romandata_t romandata[] =
 	{
 		{ 1000, _t("m") }, { 900, _t("cm" )},
@@ -83,7 +83,7 @@ litehtml::tstring litehtml::num_cvt::to_roman_lower(int value)
 
 litehtml::tstring litehtml::num_cvt::to_roman_upper(int value)
 {
-	struct romandata_t { int value; litehtml::tchar_t* numeral; };
+	struct romandata_t { int value; const litehtml::tchar_t* numeral; };
 	const struct romandata_t romandata[] =
 	{
 		{ 1000, _t("M") }, { 900, _t("CM") },


### PR DESCRIPTION
Fixes failures like:
..\..\src\plugins\help\qlitehtml\litehtml\src\num_cvt.cpp(62):
error C2440: 'initializing': cannot convert from 'const char [2]' to
'litehtml::tchar_t *' ..\..\src\plugins\help\qlitehtml\litehtml\src\num_cvt.cpp(62):
note: Conversion from string literal loses const qualifier (see /Zc:strictStrings)