### PR TITLE
Patches from Fedora packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,11 +142,13 @@ target_link_libraries(${PROJECT_NAME} PUBLIC gumbo)
 # install and export
 install(TARGETS ${PROJECT_NAME}
     EXPORT litehtmlTargets
-    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin COMPONENT libraries
+    ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+    LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
     PUBLIC_HEADER DESTINATION include/litehtml
 )
-install(FILES cmake/litehtmlConfig.cmake DESTINATION lib/cmake/litehtml)
-install(EXPORT litehtmlTargets FILE litehtmlTargets.cmake DESTINATION lib/cmake/litehtml)
+install(FILES cmake/litehtmlConfig.cmake DESTINATION lib${LIB_SUFFIX}/cmake/litehtml)
+install(EXPORT litehtmlTargets FILE litehtmlTargets.cmake DESTINATION lib${LIB_SUFFIX}/cmake/litehtml)
 
 # Binary Master.css
 if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(litehtml CXX)
 include(CTest)
 enable_testing()
 
+# Soname
+# MAJOR is incremented when symbols are removed or changed in an incompatible way
+# MINOR is incremented when new symbols are added
+set(PROJECT_MAJOR 0)
+set(PROJECT_MINOR 0)
+
 add_subdirectory(src/gumbo)
 
 set(SOURCE_LITEHTML
@@ -106,7 +112,11 @@ set(TEST_LITEHTML
     test/program.cpp
 )
 
+set(PROJECT_LIB_VERSION ${PROJECT_MAJOR}.${PROJECT_MINOR}.0)
+set(PROJECT_SO_VERSION ${PROJECT_MAJOR})
+
 add_library(${PROJECT_NAME} ${SOURCE_LITEHTML})
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_LIB_VERSION} SOVERSION ${PROJECT_SO_VERSION})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 11

--- a/src/gumbo/CMakeLists.txt
+++ b/src/gumbo/CMakeLists.txt
@@ -67,7 +67,9 @@ target_include_directories(${PROJECT_NAME} PRIVATE include/gumbo)
 # install and export
 install(TARGETS ${PROJECT_NAME}
     EXPORT gumbo
-    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin COMPONENT libraries
+    ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+    LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
     PUBLIC_HEADER DESTINATION include/gumbo
 )
-install(EXPORT gumbo FILE gumboConfig.cmake DESTINATION lib/cmake/gumbo)
+install(EXPORT gumbo FILE gumboConfig.cmake DESTINATION lib${LIB_SUFFIX}/cmake/gumbo)

--- a/src/gumbo/CMakeLists.txt
+++ b/src/gumbo/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.5)
 
 project(gumbo C)
 
+# Soname
+# MAJOR is incremented when symbols are removed or changed in an incompatible way
+# MINOR is incremented when new symbols are added
+set(PROJECT_MAJOR 0)
+set(PROJECT_MINOR 0)
+
 set(SOURCE_GUMBO
     attribute.c
     char_ref.c
@@ -37,7 +43,11 @@ set(HEADER_GUMBO
         include/gumbo/vector.h
 )
 
+set(PROJECT_LIB_VERSION ${PROJECT_MAJOR}.${PROJECT_MINOR}.0)
+set(PROJECT_SO_VERSION ${PROJECT_MAJOR})
+
 add_library(${PROJECT_NAME} ${SOURCE_GUMBO})
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_LIB_VERSION} SOVERSION ${PROJECT_SO_VERSION})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     C_STANDARD 99


### PR DESCRIPTION
I'm packaging litehtml for Fedora, and I've added the following two patches to:

- Add a library version
- Honour LIB_SUFFIX