### PR TITLE
gumbo: Fix MSVC warnings (64 bit)

### DIFF
--- a/src/gumbo/char_ref.c
+++ b/src/gumbo/char_ref.c
@@ -23009,7 +23009,7 @@ _again:
   if (cs >= 7623) {
     assert(output->first != kGumboNoChar);
     char last_char = *(te - 1);
-    int len = te - start;
+    ptrdiff_t len = te - start;
     if (last_char == ';') {
       bool matched = utf8iterator_maybe_consume_match(input, start, len, true);
       assert(matched);

--- a/src/gumbo/char_ref.rl
+++ b/src/gumbo/char_ref.rl
@@ -2493,7 +2493,7 @@ static bool consume_named_ref(
   if (cs >= %%{ write first_final; }%%) {
     assert(output->first != kGumboNoChar);
     char last_char = *(te - 1);
-    int len = te - start;
+    ptrdiff_t len = te - start;
     if (last_char == ';') {
       bool matched = utf8iterator_maybe_consume_match(input, start, len, true);
       assert(matched);

--- a/src/gumbo/error.c
+++ b/src/gumbo/error.c
@@ -33,7 +33,7 @@
 static int print_message(
     GumboParser* parser, GumboStringBuffer* output, const char* format, ...) {
   va_list args;
-  int remaining_capacity = output->capacity - output->length;
+  size_t remaining_capacity = output->capacity - output->length;
   va_start(args, format);
   int bytes_written = vsnprintf(
       output->data + output->length, remaining_capacity, format, args);

--- a/src/gumbo/include/gumbo/utf8.h
+++ b/src/gumbo/include/gumbo/utf8.h
@@ -62,7 +62,7 @@ typedef struct GumboInternalUtf8Iterator {
   int _current;
 
   // The width in bytes of the current code point.
-  int _width;
+  ptrdiff_t _width;
 
   // The SourcePosition for the current location.
   GumboSourcePosition _pos;

--- a/src/gumbo/parser.c
+++ b/src/gumbo/parser.c
@@ -812,7 +812,7 @@ InsertionLocation get_appropriate_insertion_location(
   GumboNode* last_table = open_elements->data[last_table_index];
   if (last_table->parent != NULL) {
     retval.target = last_table->parent;
-    retval.index = last_table->index_within_parent;
+    retval.index = (int)last_table->index_within_parent;
     return retval;
   }
 
@@ -2845,7 +2845,7 @@ static bool handle_in_body(GumboParser* parser, GumboToken* token) {
     text_state->_start_position = token->position;
     text_state->_type = GUMBO_NODE_TEXT;
     if (prompt_attr) {
-      int prompt_attr_length = strlen(prompt_attr->value);
+      size_t prompt_attr_length = strlen(prompt_attr->value);
       gumbo_string_buffer_destroy(parser, &text_state->_buffer);
       text_state->_buffer.data = gumbo_copy_stringz(parser, prompt_attr->value);
       text_state->_buffer.length = prompt_attr_length;

--- a/src/gumbo/tag.c
+++ b/src/gumbo/tag.c
@@ -91,5 +91,5 @@ GumboTag gumbo_tagn_enum(const char* tagname, unsigned int length) {
 }
 
 GumboTag gumbo_tag_enum(const char* tagname) {
-  return gumbo_tagn_enum(tagname, strlen(tagname));
+  return gumbo_tagn_enum(tagname, (unsigned)strlen(tagname));
 }

--- a/src/gumbo/tokenizer.c
+++ b/src/gumbo/tokenizer.c
@@ -377,7 +377,7 @@ static bool temporary_buffer_equals(GumboParser* parser, const char* text) {
   // TODO(jdtang): See if the extra strlen is a performance problem, and replace
   // it with an explicit sizeof(literal) if necessary.  I don't think it will
   // be, as this is only used in a couple of rare states.
-  int text_len = strlen(text);
+  size_t text_len = strlen(text);
   return text_len == buffer->length &&
          memcmp(buffer->data, text, text_len) == 0;
 }
@@ -751,7 +751,7 @@ static void finish_tag_name(GumboParser* parser) {
   GumboTagState* tag_state = &tokenizer->_tag_state;
 
   tag_state->_tag =
-      gumbo_tagn_enum(tag_state->_buffer.data, tag_state->_buffer.length);
+      gumbo_tagn_enum(tag_state->_buffer.data, (unsigned)tag_state->_buffer.length);
   reinitialize_tag_buffer(parser);
 }
 
@@ -839,7 +839,7 @@ static bool is_appropriate_end_tag(GumboParser* parser) {
   assert(!tag_state->_is_start_tag);
   return tag_state->_last_start_tag != GUMBO_TAG_LAST &&
          tag_state->_last_start_tag == gumbo_tagn_enum(tag_state->_buffer.data,
-                                           tag_state->_buffer.length);
+                                           (unsigned)tag_state->_buffer.length);
 }
 
 void gumbo_tokenizer_state_init(

--- a/src/gumbo/utf8.c
+++ b/src/gumbo/utf8.c
@@ -137,7 +137,7 @@ static void read_char(Utf8Iterator* iter) {
   for (const char* c = iter->_start; c < iter->_end; ++c) {
     decode(&state, &code_point, (uint32_t)(unsigned char) (*c));
     if (state == UTF8_ACCEPT) {
-      iter->_width = c - iter->_start + 1;
+      iter->_width = (int)(c - iter->_start + 1);
       // This is the special handling for carriage returns that is mandated by
       // the HTML5 spec.  Since we're looking for particular 7-bit literal
       // characters, we operate in terms of chars and only need a check for iter
@@ -181,7 +181,7 @@ static void read_char(Utf8Iterator* iter) {
 }
 
 static void update_position(Utf8Iterator* iter) {
-  iter->_pos.offset += iter->_width;
+  iter->_pos.offset += (int)iter->_width;
   if (iter->_current == '\n') {
     ++iter->_pos.line;
     iter->_pos.column = 1;

--- a/src/gumbo/vector.c
+++ b/src/gumbo/vector.c
@@ -30,7 +30,7 @@ const GumboVector kGumboEmptyVector = {NULL, 0, 0};
 void gumbo_vector_init(struct GumboInternalParser* parser,
     size_t initial_capacity, GumboVector* vector) {
   vector->length = 0;
-  vector->capacity = initial_capacity;
+  vector->capacity = (unsigned)initial_capacity;
   if (initial_capacity > 0) {
     vector->data =
         gumbo_parser_allocate(parser, sizeof(void*) * initial_capacity);


### PR DESCRIPTION
Fix warnings like
  warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
  warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data

with Microsoft (R) C/C++ Optimizing Compiler Version 19.29.30037 for x64