### PR TITLE
fix "scaring" warnings

### DIFF
--- a/include/litehtml/html.h
+++ b/include/litehtml/html.h
@@ -63,7 +63,10 @@ namespace litehtml
 
 		virtual void				get_media_features(litehtml::media_features& media) const = 0;
 		virtual void				get_language(litehtml::tstring& language, litehtml::tstring & culture) const = 0;
-		virtual litehtml::tstring	resolve_color(const litehtml::tstring& color) const  { return litehtml::tstring(); }
+		virtual litehtml::tstring resolve_color(const litehtml::tstring& /*color*/) const { return litehtml::tstring(); }
+
+	protected:
+		~document_container() = default;
 	};
 
 	void trim(tstring &s);

--- a/include/litehtml/iterators.h
+++ b/include/litehtml/iterators.h
@@ -11,6 +11,9 @@ namespace litehtml
 	{
 	public:
 		virtual bool select(const element::ptr& el) = 0;
+
+        protected:
+		~iterator_selector() = default;
 	};
 
 	class elements_iterator
@@ -62,28 +65,28 @@ namespace litehtml
 		void next_idx();
 	};
 
-	class go_inside_inline : public iterator_selector
+	class go_inside_inline final : public iterator_selector
 	{
 	public:
-		virtual bool select(const element::ptr& el);
+		bool select(const element::ptr& el) override;
 	};
 
-	class go_inside_table : public iterator_selector
+	class go_inside_table final : public iterator_selector
 	{
 	public:
-		virtual bool select(const element::ptr& el);
+		bool select(const element::ptr& el) override;
 	};
 
-	class table_rows_selector : public iterator_selector
+	class table_rows_selector final : public iterator_selector
 	{
 	public:
-		virtual bool select(const element::ptr& el);
+		bool select(const element::ptr& el) override;
 	};
 
-	class table_cells_selector : public iterator_selector
+	class table_cells_selector final : public iterator_selector
 	{
 	public:
-		virtual bool select(const element::ptr& el);
+		bool select(const element::ptr& el) override;
 	};
 }
 

--- a/include/litehtml/table.h
+++ b/include/litehtml/table.h
@@ -122,24 +122,27 @@ namespace litehtml
 	{
 	public:
 		virtual int& get(table_column& col) = 0;
+
+	protected:
+		~table_column_accessor() = default;
 	};
 
-	class table_column_accessor_max_width : public table_column_accessor
+	class table_column_accessor_max_width final : public table_column_accessor
 	{
 	public:
-		virtual int& get(table_column& col);
+		int& get(table_column& col) override;
 	};
 
-	class table_column_accessor_min_width : public table_column_accessor
+	class table_column_accessor_min_width final : public table_column_accessor
 	{
 	public:
-		virtual int& get(table_column& col);
+		int& get(table_column& col) override;
 	};
 
-	class table_column_accessor_width : public table_column_accessor
+	class table_column_accessor_width final : public table_column_accessor
 	{
 	public:
-		virtual int& get(table_column& col);
+		int& get(table_column& col) override;
 	};
 
 	struct table_cell

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -997,7 +997,7 @@ int litehtml::html_tag::get_floats_height(element_float el_float) const
 		}
 
 
-		for(const auto fb : m_floats_right)
+		for(const auto& fb : m_floats_right)
 		{
 			process = false;
 			switch(el_float)
@@ -1674,7 +1674,7 @@ bool litehtml::html_tag::is_body()  const
 	return false;
 }
 
-void litehtml::html_tag::set_data( const tchar_t* data )
+void litehtml::html_tag::set_data( const tchar_t* /*data*/ )
 {
 
 }
@@ -4276,7 +4276,7 @@ int litehtml::html_tag::render_box(int x, int y, int max_width, bool second_pass
 	return ret_width;
 }
 
-int litehtml::html_tag::render_table(int x, int y, int max_width, bool second_pass /*= false*/)
+int litehtml::html_tag::render_table(int x, int y, int max_width, bool /*second_pass = false*/)
 {
 	if (!m_grid) return 0;
 
@@ -4568,7 +4568,6 @@ int litehtml::html_tag::render_table(int x, int y, int max_width, bool second_pa
 		min_height = (int)m_css_min_height.val();
 	}
 
-	int extra_row_height = 0;
 	int minimum_table_height = std::max(block_height, min_height);
 
 	m_grid->calc_rows_height(minimum_table_height - table_height_spacing, m_border_spacing_y);

--- a/src/web_color.cpp
+++ b/src/web_color.cpp
@@ -231,15 +231,15 @@ litehtml::tstring litehtml::web_color::resolve_name(const tchar_t* name, litehtm
 	{
 		if(!t_strcasecmp(name, g_def_colors[i].name))
 		{
-            return std::move(litehtml::tstring(g_def_colors[i].rgb));
+            return litehtml::tstring(g_def_colors[i].rgb);
 		}
 	}
     if (callback)
     {
         litehtml::tstring clr = callback->resolve_color(name);
-        return std::move(clr);
+        return clr;
     }
-    return std::move(litehtml::tstring());
+    return litehtml::tstring();
 }
 
 bool litehtml::web_color::is_color(const tchar_t* str)


### PR DESCRIPTION
1. usage of virtual functions without destructor,
   not public not-virtual destructor + final convinced compiler that
   all ok (in theory that also can help C++ compiler devertualization optimization pass)
2. couple of unused variables and arguments (the most noisy one)
3. extra copy in cycle
4. std::move prevent copy elision warning