### PR TITLE
Add a custom 'strtod' implementation that ignores the current locale.

### DIFF
--- a/include/litehtml/html.h
+++ b/include/litehtml/html.h
@@ -76,6 +76,7 @@ namespace litehtml
 	tstring::size_type find_close_bracket(const tstring &s, tstring::size_type off, tchar_t open_b = _t('('), tchar_t close_b = _t(')'));
 	void split_string(const tstring& str, string_vector& tokens, const tstring& delims, const tstring& delims_preserve = _t(""), const tstring& quote = _t("\""));
 	void join_string(tstring& str, const string_vector& tokens, const tstring& delims);
+	double strtod(const char *nptr, char **endptr);
 
 	inline int round_f(float val)
 	{

--- a/include/litehtml/os_types.h
+++ b/include/litehtml/os_types.h
@@ -80,7 +80,7 @@ namespace litehtml
 
 	#define t_strtol			strtol
 	#define t_atoi				atoi
-	#define t_strtod			strtod
+	#define t_strtod			litehtml::document::strtod
 	#define t_strstr			strstr
 	#define t_tolower			tolower
 	#define t_isdigit			isdigit

--- a/include/litehtml/os_types.h
+++ b/include/litehtml/os_types.h
@@ -80,7 +80,7 @@ namespace litehtml
 
 	#define t_strtol			strtol
 	#define t_atoi				atoi
-	#define t_strtod			litehtml::document::strtod
+	#define t_strtod			litehtml::strtod
 	#define t_strstr			strstr
 	#define t_tolower			tolower
 	#define t_isdigit			isdigit

--- a/src/html.cpp
+++ b/src/html.cpp
@@ -167,3 +167,64 @@ void litehtml::join_string(tstring& str, const string_vector& tokens, const tstr
 
 	str = ss.str();
 }
+
+double litehtml::strtod(const char *nptr, char **endptr)
+{
+	tstring num;
+	tstring dec;
+	const char *p;
+	double val = 0;
+	bool neg;
+	double f;
+	int i;
+	
+	p = nptr;
+	
+	if (*p == '+')
+	{
+		neg = false;
+		p++;
+	}
+	else if (*p == '-')
+	{
+		neg = true;
+		p++;
+	}
+	
+	while (*p)
+	{
+		if (*p == '.' || !t_isdigit(*p))
+			break;
+		num += *p++;
+	}
+	
+	f = 1.0;
+	for (i = num.length() - 1; i >= 0; i--)
+	{
+		val += (num[i] - '0') * f;
+		f *= 10.0;
+	}
+	
+	if (*p == '.')
+	{
+		p++;
+		while(*p)
+		{
+			if (!t_isdigit(*p))
+				break;
+			dec += *p++;
+		}
+		
+		f = 1.0;
+		for (i = 0; i < dec.length(); i++)
+		{
+			f /= 10.0;
+			val += (dec[i] - '0') * f;
+		}
+	}
+	
+	if (endptr)
+		*endptr = (char *)p;
+	
+	return neg ? (-val) : val;
+}


### PR DESCRIPTION
It has been implemented in the `html.cpp` file, inside the `litehtml` namespace.

This is not a complete `strtod` implementation:
- It ignores the exponent part.
- It does not set `errno`.

But it should be enough for the two uses of that function in `litehtml` source code.