### PR TITLE
fixed style property 'white-space: pre-wrap'

### DIFF
--- a/include/litehtml/el_space.h
+++ b/include/litehtml/el_space.h
@@ -13,6 +13,7 @@ namespace litehtml
 
 		bool is_white_space() const override;
 		bool is_break() const override;
+        bool is_space() const override;
 	};
 }
 

--- a/include/litehtml/element.h
+++ b/include/litehtml/element.h
@@ -135,6 +135,7 @@ namespace litehtml
 		virtual void				apply_stylesheet(const litehtml::css& stylesheet);
 		virtual void				refresh_styles();
 		virtual bool				is_white_space() const;
+        virtual bool                is_space() const;
 		virtual bool				is_body() const;
 		virtual bool				is_break() const;
 		virtual int					get_base_line();

--- a/src/box.cpp
+++ b/src/box.cpp
@@ -302,7 +302,7 @@ bool litehtml::line_box::can_hold(const element::ptr &el, white_space ws) const
 		return false;
 	}
 
-	if(ws == white_space_nowrap || ws == white_space_pre)
+	if(ws == white_space_nowrap || ws == white_space_pre || (ws == white_space_pre_wrap && el->is_space()))
 	{
 		return true;
 	}

--- a/src/el_space.cpp
+++ b/src/el_space.cpp
@@ -32,3 +32,9 @@ bool litehtml::el_space::is_break() const
 	}
 	return false;
 }
+
+bool litehtml::el_space::is_space() const
+{
+    return true;
+}
+

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -373,6 +373,7 @@ void litehtml::element::get_inline_boxes( position::vector& boxes )					LITEHTML
 void litehtml::element::parse_styles( bool is_reparse /*= false*/ )					LITEHTML_EMPTY_FUNC
 const litehtml::tchar_t* litehtml::element::get_attr( const tchar_t* name, const tchar_t* def /*= 0*/ ) const LITEHTML_RETURN_FUNC(def)
 bool litehtml::element::is_white_space() const										LITEHTML_RETURN_FUNC(false)
+bool litehtml::element::is_space() const										    LITEHTML_RETURN_FUNC(false)
 bool litehtml::element::is_body() const												LITEHTML_RETURN_FUNC(false)
 bool litehtml::element::is_break() const											LITEHTML_RETURN_FUNC(false)
 int litehtml::element::get_base_line()												LITEHTML_RETURN_FUNC(0)


### PR DESCRIPTION
'white-space:pre-wrap' allows to start new line with white-space if client width is configured not to fit trailing space at any line.
Tested with following html content:
```
<!DOCTYPE html>
<html>
<head>
<style>
div {
  white-space: pre-wrap;
}
</style>
</head>
<body>
<div>
This is some text. This is some text. This is some text.
</div>
</body>
</html>
```
This can lead in the following output:
```
This is some text. This is some text.
 This is some text.   <---   line starts with white-space!
```

Try yourself by shrinking browser window width to see the wrong line break and compare same content at e.g. w3schools.com