### PR TITLE
gumbo.h (and others) has two problems among them:

### DIFF
--- a/src/gumbo/include/gumbo.h
+++ b/src/gumbo/include/gumbo.h
@@ -43,8 +43,12 @@
 #define GUMBO_GUMBO_H_
 
 #ifdef _MSC_VER
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+#ifndef fileno
 #define fileno _fileno
+#endif
 #endif
 
 #include <stdbool.h>

--- a/src/gumbo/include/gumbo/error.h
+++ b/src/gumbo/include/gumbo/error.h
@@ -19,7 +19,9 @@
 #ifndef GUMBO_ERROR_H_
 #define GUMBO_ERROR_H_
 #ifdef _MSC_VER
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 #endif
 #include <stdint.h>
 

--- a/src/gumbo/include/gumbo/util.h
+++ b/src/gumbo/include/gumbo/util.h
@@ -20,7 +20,9 @@
 #ifndef GUMBO_UTIL_H_
 #define GUMBO_UTIL_H_
 #ifdef _MSC_VER
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 #endif
 #include <stdbool.h>
 #include <stddef.h>


### PR DESCRIPTION
1. #define _CRT_SECURE_NO_WARNINGS is done unconditionally (but what if I've already done it?)
2. #define fileno _fileno is done unconditionally.. this actually is more related to compiling against the windows platform than using MSC. anyway a simple way to resolve it is to conditionalize it.