### PR TITLE
Add styles for u element

### DIFF
--- a/include/litehtml/master_css.h
+++ b/include/litehtml/master_css.h
@@ -57,6 +57,10 @@ i, em {
 	font-style:italic;
 }
 
+u {
+	text-decoration:underline
+}
+
 center 
 {
 	text-align:center;


### PR DESCRIPTION
This adds styles (underline) for the `<u>` element.

The styles for `<b>`/`<strong>` and `<i>`/`<em>` additionally have `display:inline;`. Should that be removed, or should it be added to the styles for `<u>` here?