### PR TITLE
allow use inside shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ enable_testing()
 set(PROJECT_MAJOR 0)
 set(PROJECT_MINOR 0)
 
+# https://stackoverflow.com/questions/38296756/what-is-the-idiomatic-way-in-cmake-to-add-the-fpic-compiler-option
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 option(EXTERNAL_GUMBO "Link against external gumbo instead of shipping a bundled copy" OFF)
 
 if(NOT EXTERNAL_GUMBO)

--- a/python/bad-ok.html
+++ b/python/bad-ok.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <head>
+        <style type="text/css">
+            body {
+                background-color: #ffffff;
+                color: #000000;
+                font-family: 'Arial', sans-serif;
+                font-size: 11pt;
+                margin: 0;
+                padding: 1px 5%;
+            }
+            div.body {
+                width: 100%;
+                min-width: 480px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+            table {
+                border-collapse: collapse;
+            }
+            .normalna {
+                width: 100%;
+            }
+            .wypelniane {
+                border: 1px solid black;
+                font-size: 1.2em;
+                padding: 1px;
+                vertical-align: top;
+                text-align: left;
+                background-color: white;
+            }
+            .opisrubryki {
+                font-size: 0.5em;
+                margin-bottom: 0.2em;
+                text-align: left;
+                font-weight: bold;
+                text-transform: none;
+            }
+            .nazwa-dla-kodu {
+                font-size: 0.9em;
+            }
+            table.normalna {
+                width: 100%;
+                margin: 0;
+                border: 1px solid black;
+            }
+            .rowdiv {
+#                height: 2em;
+            }
+        </style>
+    </head>
+    <body>
+        <div
+            class="deklaracja"
+        >
+            <table class="normalna">
+                <tr>
+                    <td class="wypelniane" style="width: 50%">
+                        <div class="opisrubryki">
+                            12. Identyfikator podatkowy NIP / numer PESEL
+                        </div>
+                        33033000456
+                    </td>
+                    <td class="wypelniane" style="width: 50%">
+                        <div class="rowdiv">
+                            <div class="opisrubryki">
+                                13. Zagraniczny numer identyfikacyjny podatnika
+                                <font style="font-weight: normal"
+                                    >(numer dokumentu stwierdzaj&#261;cego
+                                    to&#380;samo&#347;&#263;)<sup
+                                        >11)</sup
+                                    ></font
+                                >
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="wypelniane" style="width: 50%">
+                        <div class="rowdiv">
+                            <div class="opisrubryki">
+                                14. Rodzaj numeru identyfikacyjnego (dokumentu
+                                stwierdzaj&#261;cego
+                                to&#380;samo&#347;&#263;)<font
+                                    style="font-weight: normal"
+                                    ><sup>12)</sup></font
+                                >
+                            </div>
+                        </div>
+                    </td>
+                    <td class="wypelniane" style="width: 50%">
+                        <div class="rowdiv">
+                            <div class="opisrubryki">
+                                15. Kraj wydania numeru identyfikacyjnego
+                                (dokumentu stwierdzaj&#261;cego
+                                to&#380;samo&#347;&#263;)
+                                <font style="font-weight: normal"
+                                    ><sup>12)</sup></font
+                                >
+                            </div>
+                            PL&#160;
+                            <span class="nazwa-dla-kodu">(POLSKA)</span>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </body>
+</html>

--- a/python/bad.html
+++ b/python/bad.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <head>
+        <style type="text/css">
+            body {
+                background-color: #ffffff;
+                color: #000000;
+                font-family: 'Arial', sans-serif;
+                font-size: 11pt;
+                margin: 0;
+                padding: 1px 5%;
+            }
+            div.body {
+                width: 100%;
+                min-width: 480px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+            table {
+                border-collapse: collapse;
+            }
+            .normalna {
+                width: 100%;
+            }
+            .wypelniane {
+                border: 1px solid black;
+                font-size: 1.2em;
+                padding: 1px;
+                vertical-align: top;
+                text-align: left;
+                background-color: white;
+            }
+            .opisrubryki {
+                font-size: 0.5em;
+                margin-bottom: 0.2em;
+                text-align: left;
+                font-weight: bold;
+                text-transform: none;
+            }
+            .nazwa-dla-kodu {
+                font-size: 0.9em;
+            }
+            table.normalna {
+                width: 100%;
+                margin: 0;
+                border: 1px solid black;
+            }
+            .rowdiv {
+                height: 2em;
+            }
+        </style>
+    </head>
+    <body>
+        <div
+            class="deklaracja"
+        >
+            <table class="normalna">
+                <tr>
+                    <td class="wypelniane" style="width: 50%">
+                        <div class="opisrubryki">
+                            12. Identyfikator podatkowy NIP / numer PESEL
+                        </div>
+                        62020215910
+                    </td>
+                    <td class="wypelniane" style="width: 50%">
+                        <div class="rowdiv">
+                            <div class="opisrubryki">
+                                13. Zagraniczny numer identyfikacyjny podatnika
+                                <font style="font-weight: normal"
+                                    >(numer dokumentu stwierdzaj&#261;cego
+                                    to&#380;samo&#347;&#263;)<sup
+                                        >11)</sup
+                                    ></font
+                                >
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="wypelniane" style="width: 50%">
+                        <div class="rowdiv">
+                            <div class="opisrubryki">
+                                14. Rodzaj numeru identyfikacyjnego (dokumentu
+                                stwierdzaj&#261;cego
+                                to&#380;samo&#347;&#263;)<font
+                                    style="font-weight: normal"
+                                    ><sup>12)</sup></font
+                                >
+                            </div>
+                        </div>
+                    </td>
+                    <td class="wypelniane" style="width: 50%">
+                        <div class="rowdiv">
+                            <div class="opisrubryki">
+                                15. Kraj wydania numeru identyfikacyjnego
+                                (dokumentu stwierdzaj&#261;cego
+                                to&#380;samo&#347;&#263;)
+                                <font style="font-weight: normal"
+                                    ><sup>12)</sup></font
+                                >
+                            </div>
+                            PL&#160;
+                            <span class="nazwa-dla-kodu">(POLSKA)</span>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </body>
+</html>

--- a/python/html2bmp.cc
+++ b/python/html2bmp.cc
@@ -1,0 +1,50 @@
+#include <sstream>
+#include <fstream>
+#include "../containers/test/test_container.h"
+#include "../containers/test/Bitmap.h"
+using namespace std;
+
+void error(const char* msg) { puts(msg); exit(1); }
+
+string readfile(string filename)
+{
+	stringstream ss;
+	ifstream(filename) >> ss.rdbuf();
+	return ss.str();
+}
+
+Bitmap draw(document::ptr doc, int width, int height)
+{
+	Bitmap bmp(width, height);
+	position clip(0, 0, width, height);
+
+	doc->draw((uint_ptr)&bmp, 0, 0, &clip);
+
+	position pos = bmp.find_picture();
+	bmp.resize(min(pos.right() + 8, width), min(pos.bottom() + 8, height));
+
+	return bmp;
+}
+
+void test(string filename)
+{
+	string html = readfile(filename);
+
+	int width = 1600, height = 6000; // image will be cropped to contain only the "inked" part
+//	int width = 595, height = 842;
+//	int width = 1190, height = 6000;
+	test_container container(width, height, ".");
+
+	auto doc = document::createFromString(html.c_str(), &container);
+	doc->render(width);
+	Bitmap bmp = draw(doc, width, height);
+
+	bmp.save(filename + ".png");
+}
+
+int main(int argc, char *argv[], char **envp) {
+    if( argc != 2 )
+        printf("usage html2bmp filename\n");
+    else
+        test(argv[1]);
+}

--- a/python/html2bmp.sh
+++ b/python/html2bmp.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+g++ -o html2bmp -O2 \
+-I ../include \
+html2bmp.cc \
+-I ../containers/test \
+../containers/test/Bitmap.cpp \
+../containers/test/Font.cpp \
+../containers/test/lodepng.cpp \
+../containers/test/test_container.cpp \
+-L../build -llitehtml \
+-L../build/src/gumbo -lgumbo

--- a/python/litehtml.py
+++ b/python/litehtml.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env vpython3
+import sys
+import wx
+from ctypes import *
+
+class CreateFont(Structure):
+    _fields_ = (
+        ('face', c_char_p),
+        ('size', c_int),
+        ('weight', c_int),
+        ('italic', c_int),
+        ('decor', c_uint),
+        # out
+        ('ascent', c_int),
+        ('descent', c_int),
+        ('height', c_int),
+        ('xheight', c_int),
+        ('font', c_int),
+    )
+
+class TextWidth(Structure):
+    _fields_ = (
+        ('text', c_char_p),
+        ('font', c_int),
+        # out
+        ('width', c_int),
+    )
+
+class DrawText(Structure):
+    _fields_ = (
+        ('dc', c_int),
+        ('text', c_char_p),
+        ('font', c_int),
+        ('color', c_uint),
+        ('x', c_int),
+        ('y', c_int),
+    )
+
+class DrawBackground(Structure):
+    _fields_ = (
+        ('dc', c_int),
+        ('x', c_int),
+        ('y', c_int),
+        ('w', c_int),
+        ('h', c_int),
+        ('color', c_uint),
+    )
+
+class DrawBorders(Structure):
+    _fields_ = (
+        ('dc', c_int),
+        ('left', c_int),
+        ('right', c_int),
+        ('top', c_int),
+        ('bottom', c_int),
+        ('colorLeft', c_uint),
+        ('colorRight', c_uint),
+        ('colorTop', c_uint),
+        ('colorBottom', c_uint),
+        ('widthLeft', c_uint),
+        ('widthRight', c_uint),
+        ('widthTop', c_uint),
+        ('widthBottom', c_uint),
+    )
+
+class DrawMarker(Structure):
+    _fields_ = (
+        ('dc', c_int),
+        ('x', c_int),
+        ('y', c_int),
+        ('w', c_int),
+        ('h', c_int),
+        ('mt', c_int),
+        ('color', c_uint),
+    )
+
+class PT2PX(Structure):
+    _fields_ = (
+        ('pt', c_int),
+    )
+
+class LiteHtml:
+    def __init__(self, width, height):
+        self.width = width
+        self.height = height
+        self.pylib = CDLL("./py_container.so")
+        self.pycb = CFUNCTYPE(None, c_char_p, POINTER(None))(self.cbproc)
+        self.pyclass = self.pylib.container_create(width, height, self.pycb)
+
+    def reset(self):
+        self.bmp = wx.Bitmap(self.width, self.height, 32)
+        self.dc = wx.MemoryDC()
+        self.dc.SelectObject(self.bmp)
+        self.fonts = {}
+        self.ppi = self.dc.GetPPI()
+
+    def close(self):
+        self.pylib.container_delete(self.pyclass)
+
+    def GetColourFromRGBA(self, rgba):
+        a = rgba & 0xff; rgba >>= 8
+        b = rgba & 0xff; rgba >>= 8
+        g = rgba & 0xff; rgba >>= 8
+        r = rgba & 0xff; rgba >>= 8
+        return wx.Colour(r, g, b, a)
+
+    def cbproc(self, name, argp):
+        name = name.decode('utf8')
+        getattr(self, name)(argp)
+
+    def createFont(self, argp):
+        pfi = cast(argp, POINTER(CreateFont))
+        fi = pfi.contents
+        face = fi.face
+        if not face:
+            face = 'Times New Roman'
+        else:
+            face = face.split(b',')[0].strip()
+            if face[0] == b'"':
+                face = face.split(b'"')[1]
+            elif face[0] == b"'":
+                face = face.split(b"'")[1]
+            face = face.decode('utf8')
+        if fi.italic:
+            style = wx.FONTSTYLE_ITALIC
+        else:
+            style = wx.FONTSTYLE_NORMAL
+        weigths = {
+            100:wx.FONTWEIGHT_THIN,
+            200:wx.FONTWEIGHT_EXTRALIGHT,
+            300:wx.FONTWEIGHT_LIGHT,
+            400:wx.FONTWEIGHT_NORMAL,
+            500:wx.FONTWEIGHT_MEDIUM,
+            600:wx.FONTWEIGHT_SEMIBOLD,
+            700:wx.FONTWEIGHT_BOLD,
+            800:wx.FONTWEIGHT_EXTRABOLD,
+            900:wx.FONTWEIGHT_HEAVY,
+            1000:wx.FONTWEIGHT_EXTRAHEAVY,
+        }
+        weight = weigths.get(fi.weight, wx.FONTWEIGHT_NORMAL)
+        underline = fi.decor != 0
+        font = wx.Font(fi.size, wx.FONTFAMILY_DEFAULT, style, weight, underline, face)
+        nfont = len(self.fonts)
+        self.fonts[nfont] = font
+        if 0:
+            w, h, d, e = self.dc.GetFullTextExtent('H', font)
+            xw, xh, xd, xe = self.dc.GetFullTextExtent('x', font)
+            a = 0
+        else:
+            self.dc.SetFont(font)
+            fm = self.dc.GetFontMetrics()
+            a = fm.ascent
+            d = fm.descent
+            h = fm.height
+            xh = h
+        fi.ascent = a
+        fi.descent = d
+        fi.height = h
+        fi.xheight = xh
+        fi.font = nfont
+
+    def textWidth(self, argp):
+        pfi = cast(argp, POINTER(TextWidth))
+        fi = pfi.contents
+
+        font = self.fonts[fi.font]
+        text = fi.text.decode('utf8')
+        w, h, d, e = self.dc.GetFullTextExtent(text, font)
+        fi.width = w
+
+    def drawText(self, argp):
+        pfi = cast(argp, POINTER(DrawText))
+        fi = pfi.contents
+
+        font = self.fonts[fi.font]
+        text = fi.text.decode('utf8')
+        color = self.GetColourFromRGBA(fi.color)
+        x = fi.x
+        y = fi.y
+
+        self.dc.SetFont(font)
+        self.dc.SetTextForeground(color)
+        self.dc.DrawText(text, x, y)
+
+    def drawBackground(self, argp):
+        pfi = cast(argp, POINTER(DrawBackground))
+        fi = pfi.contents
+
+        x = fi.x
+        y = fi.y
+        w = fi.w
+        h = fi.h
+        color = self.GetColourFromRGBA(fi.color)
+        pt = [
+            (x, y), (x+w, y), (x+w, y+h), (x, y+h), (x, y)
+        ]
+        self.dc.SetBrush(wx.Brush(color))
+        self.dc.DrawPolygon(pt)
+        self.dc.SetBrush(wx.NullBrush)
+
+    def drawMarker(self, argp):
+        pfi = cast(argp, POINTER(DrawMarker))
+        fi = pfi.contents
+
+        x = fi.x
+        y = fi.y
+        w = fi.w
+        h = fi.h
+        mt = fi.mt
+        color = self.GetColourFromRGBA(fi.color)
+        print('drawMarker', x, y, w, h)
+
+    def pt2px(self, argp):
+        pfi = cast(argp, POINTER(PT2PX))
+        fi = pfi.contents
+
+        pt = fi.pt
+        fi.pt = int(pt * self.ppi[0] / 72)
+
+    def drawBorders(self, argp):
+        pfi = cast(argp, POINTER(DrawBorders))
+        fi = pfi.contents
+
+        left = fi.left
+        right = fi.right
+        top = fi.top
+        bottom = fi.bottom
+        colorLeft = self.GetColourFromRGBA(fi.colorLeft)
+        colorRight = self.GetColourFromRGBA(fi.colorRight)
+        colorTop = self.GetColourFromRGBA(fi.colorTop)
+        colorBottom = self.GetColourFromRGBA(fi.colorBottom)
+        widthLeft = fi.widthLeft
+        widthRight = fi.widthRight
+        widthTop = fi.widthTop
+        widthBottom = fi.widthBottom
+
+        self.dc.SetPen(wx.Pen(colorLeft, widthLeft))
+        self.dc.DrawLine(left, top, left, bottom)
+        self.dc.SetPen(wx.Pen(colorTop, widthTop))
+        self.dc.DrawLine(left, top, right, top)
+        self.dc.SetPen(wx.Pen(colorRight, widthRight))
+        self.dc.DrawLine(right, top, right, bottom)
+        self.dc.SetPen(wx.Pen(colorBottom, widthBottom))
+        self.dc.DrawLine(left, bottom, right, bottom)
+
+    def render(self, fname):
+        self.reset()
+        html = open(fname, 'rb').read()
+        self.pylib.container_render(self.pyclass, html)
+        #bmp = self.dc.GetSelectedBitmap()
+        self.bmp.SaveFile(fname+'.png', wx.BITMAP_TYPE_PNG)
+
+def main():
+    wxapp = wx.App(False)
+    v = 3.96* 96 / 72
+    print('v=', v)
+    w = int(210 * v)
+    h = int(297 * v)
+    #w = 1600
+    cls = LiteHtml(w, h)
+    if len(sys.argv) > 1:
+        cls.render(sys.argv[1])
+    elif 1:
+        for i in (0, 1, 2, 3):
+            cls.render("pit-11-29-%d.html"%i)
+    else:
+        cls.render("pit-11-29.html")
+    cls.close()
+
+if __name__ == '__main__':
+    main()

--- a/python/py_container.cpp
+++ b/python/py_container.cpp
@@ -1,0 +1,220 @@
+#include "py_container.h"
+
+extern "C" uint_ptr container_create(int width, int height, PYCB py) {
+    py_container *c = new py_container(width, height, py);
+    return (uint_ptr)c;
+}
+
+extern "C" void container_delete(uint_ptr *ctr) {
+    py_container *c = (py_container *)ctr;
+    delete c;
+}
+
+extern "C" void container_render(uint_ptr *ctr, char *html) {
+    py_container *c = (py_container *)ctr;
+    position clip(0, 0, c->width, c->height);
+    auto doc = document::createFromString(html, c);
+    doc->render(c->width);
+    doc->draw((uint_ptr)NULL, 0, 0, &clip);
+}
+
+struct CreateFont {
+// in
+    const char *faceName;
+    int size;
+    int weight;
+    int italic;
+    unsigned int decoration;
+// out
+    int ascent;
+    int descent;
+    int height;
+    int x_height;
+    int font;
+};
+
+// note: font is selected only by size, name and style are not used
+uint_ptr py_container::create_font(const char* faceName, int size, int weight, font_style italic, unsigned int decoration, font_metrics* fm)
+{
+    struct CreateFont fi;
+    fi.faceName = faceName;
+    fi.size = size;
+    fi.weight = weight;
+    fi.italic = (int)italic;
+    fi.decoration = decoration;
+    (*py)("createFont", (void *)&fi);
+
+    if (fm)
+    {
+        fm->ascent   = fi.ascent;
+        fm->descent  = fi.descent;
+        fm->height   = fi.height;
+        fm->x_height = fi.x_height;
+    }
+    return (uint_ptr)fi.font;
+}
+
+struct TextWidth {
+// in
+    const char *text;
+    int font;
+// out
+    int width;
+};
+
+int py_container::text_width(const char* text, uint_ptr hFont)
+{
+    struct TextWidth fi;
+    fi.text = text;
+    fi.font = (int)hFont;
+    (*py)("textWidth", (void *)&fi);
+    return fi.width;
+}
+
+#define C32(c, s) (((unsigned int)c)<<s)
+#define RGBA(color) C32(color.red, 24) | C32(color.green, 16) | C32(color.blue, 8) | C32(color.alpha, 0)
+struct DrawText {
+// in
+    int dc;
+    const char *text;
+    int font;
+    unsigned int color;
+    int x;
+    int y;
+};
+
+void py_container::draw_text(uint_ptr hdc, const char* text, uint_ptr hFont, web_color color, const position& pos)
+{
+    struct DrawText fi;
+    fi.dc = (int)hdc;
+    fi.text = text;
+    fi.font = (int)hFont;
+    fi.color = RGBA(color);
+    fi.x = pos.x;
+    fi.y = pos.y;
+    (*py)("drawText", (void *)&fi);
+}
+
+struct PT2PX {
+    int pt;
+};
+
+int py_container::pt_to_px(int pt) const {
+    struct PT2PX fi;
+    fi.pt = pt;
+    (*py)("pt2px", (void *)&fi);
+    return fi.pt;
+}
+
+int py_container::get_default_font_size() const {
+    return 16;
+}
+
+const char* py_container::get_default_font_name() const {
+    return "";
+}
+
+struct DrawBackground {
+// in
+    int dc;
+    int x;
+    int y;
+    int w;
+    int h;
+    unsigned int color;
+// out
+};
+
+void py_container::draw_background(uint_ptr hdc, const background_paint& bg)
+{
+    struct DrawBackground fi;
+    fi.dc = (int)hdc;
+    fi.x = bg.border_box.x;
+    fi.y = bg.border_box.y;
+    fi.w = bg.border_box.width;
+    fi.h = bg.border_box.height;
+    fi.color = RGBA(bg.color);
+    (*py)("drawBackground", (void *)&fi);
+}
+
+struct DrawBorders {
+// in
+    int dc;
+    int left;
+    int right;
+    int top;
+    int bottom;
+    unsigned int colorLeft;
+    unsigned int colorRight;
+    unsigned int colorTop;
+    unsigned int colorBottom;
+    int widthLeft;
+    int widthRight;
+    int widthTop;
+    int widthBottom;
+// out
+};
+void py_container::draw_borders(uint_ptr hdc, const borders& borders, const position& pos, bool root)
+{
+    struct DrawBorders fi;
+    fi.dc = (int)hdc;
+    fi.left = pos.left();
+    fi.right = pos.right();
+    fi.top = pos.top();
+    fi.bottom = pos.bottom();
+    fi.colorLeft = RGBA(borders.left.color);
+    fi.colorRight = RGBA(borders.right.color);
+    fi.colorTop = RGBA(borders.top.color);
+    fi.colorBottom = RGBA(borders.bottom.color);
+    fi.widthLeft = borders.left.width;
+    fi.widthRight = borders.right.width;
+    fi.widthTop = borders.top.width;
+    fi.widthBottom = borders.bottom.width;
+    (*py)("drawBorders", (void *)&fi);
+}
+
+struct DrawMarker {
+// in
+    int dc;
+    int x;
+    int y;
+    int w;
+    int h;
+    int mt;
+    unsigned int color;
+// out
+};
+
+void py_container::draw_list_marker(uint_ptr hdc, const list_marker& marker)
+{
+    struct DrawMarker fi;
+
+    int top_margin = marker.pos.height / 3;
+    if (top_margin < 4)
+        top_margin = 0;
+
+    int draw_x = marker.pos.x;
+    int draw_y = marker.pos.y + top_margin;
+    int draw_width = marker.pos.height - top_margin * 2;
+    int draw_height = marker.pos.height - top_margin * 2;
+
+    fi.dc = (int)hdc;
+    fi.x = draw_x;
+    fi.y = draw_y;
+    fi.w = draw_width;
+    fi.h = draw_height;
+    fi.mt = (int)marker.marker_type;
+    fi.color = RGBA(marker.color);
+    (*py)("drawMarker", (void *)&fi);
+}
+
+void py_container::import_css(string& text, const string& url, string& baseurl)
+{
+    baseurl = url;
+    text = "";
+}
+
+void py_container::get_client_rect(position& client) const
+{
+    client = position(0, 0, width, height);
+}

--- a/python/py_container.h
+++ b/python/py_container.h
@@ -1,0 +1,44 @@
+#include <litehtml.h>
+using namespace litehtml;
+
+typedef void (*PYCB)(const char *proc, void *arg);
+
+class py_container : public document_container
+{
+public:
+	int width;
+	int height;
+	PYCB py;
+
+	py_container(int width, int height, PYCB py) : width(width), height(height), py(py) {}
+
+	uint_ptr		create_font(const char* faceName, int size, int weight, font_style italic, unsigned int decoration, font_metrics* fm) override;
+	void			delete_font(uint_ptr hFont) override {}
+	int			text_width(const char* text, uint_ptr hFont) override;
+	void			draw_text(uint_ptr hdc, const char* text, uint_ptr hFont, web_color color, const position& pos) override;
+	int			pt_to_px(int pt) const override;
+	int			get_default_font_size() const override;
+	const char*		get_default_font_name() const override;
+	void 			load_image(const char* src, const char* baseurl, bool redraw_on_ready) override {}
+	void			get_image_size(const char* src, const char* baseurl, size& sz) override {}
+	void			draw_background(uint_ptr hdc, const background_paint& bg) override;
+	void			draw_borders(uint_ptr hdc, const borders& borders, const position& draw_pos, bool root) override;
+	void 			draw_list_marker(uint_ptr hdc, const list_marker& marker) override;
+	element::ptr	create_element(const char* tag_name,
+								   const string_map& attributes,
+								   const document::ptr& doc) override { return 0; }
+	void			get_media_features(media_features& media) const override {}
+	void			get_language(string& language, string& culture) const override {}
+	void 			link(const document::ptr& doc, const element::ptr& el) override {}
+
+	void			transform_text(string& text, text_transform tt) override {}
+	void			set_clip(const position& pos, const border_radiuses& bdr_radius, bool valid_x, bool valid_y) override {}
+	void			del_clip() override {}
+
+	void 			set_caption(const char* caption) override {}
+	void 			set_base_url(const char* base_url) override {}
+	void			on_anchor_click(const char* url, const element::ptr& el) override {}
+	void			set_cursor(const char* cursor) override {}
+	void			import_css(string& text, const string& url, string& baseurl) override;
+	void			get_client_rect(position& client) const override;
+};

--- a/python/py_container.sh
+++ b/python/py_container.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+g++ -O2 \
+-I ../include \
+-o py_container.so -fPIC -shared \
+py_container.cpp \
+-L../build -llitehtml \
+-L../build/src/gumbo -lgumbo


### PR DESCRIPTION
Hi,

Small change - using litehtml in dynamically linked libraries.
And an example of using a container (.so) in python, wxPython version 4.x is required.
bug.html - show when the height of the subelement is not taken into account.
