### PR TITLE
add litehtml-specific testing option in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(litehtml LANGUAGES C CXX)
-include(CTest)
-enable_testing()
+
+
+option(LITEHTML_BUILD_TESTING "enable testing for litehtml" ON)
+
+if(LITEHTML_BUILD_TESTING)
+    include(CTest)
+    enable_testing()
+endif()
 
 # Soname
 # MAJOR is incremented when symbols are removed or changed in an incompatible way
@@ -183,7 +189,7 @@ install(EXPORT litehtmlTargets FILE litehtmlTargets.cmake DESTINATION lib${LIB_S
 
 # Tests
 
-if (BUILD_TESTING)
+if (LITEHTML_BUILD_TESTING)
     option(EXTERNAL_GTEST "Use external GoogleTest instead of fetching from GitHub" OFF)
 
     if (EXTERNAL_GTEST)


### PR DESCRIPTION
since cmake does not have a built in way to specify testing options per-project this will allow tests for litehtml to be enabled or disabled explicitly when it is brought in as a dependency in a larger cmake project