### PR TITLE
media_query: Treat unknown media type as none

### DIFF
--- a/src/media_query.cpp
+++ b/src/media_query.cpp
@@ -88,8 +88,7 @@ litehtml::media_query::ptr litehtml::media_query::create_from_string(const strin
 			}
 		} else
 		{
-			query->m_media_type = (media_type) value_index(token, media_type_strings, media_type_all);
-
+			query->m_media_type = (media_type) value_index(token, media_type_strings, media_type_none);
 		}
 	}
 


### PR DESCRIPTION
According to https://www.w3.org/TR/mediaqueries-5/ section 3.2, Error Handling, an unknown media-type must be treated as not matching.