### PR TITLE
Add specifying a working directory for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,5 +247,5 @@ if (LITEHTML_BUILD_TESTING)
     )
 
     include(GoogleTest)
-    gtest_discover_tests(${TEST_NAME})
+    gtest_discover_tests(${TEST_NAME} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
 endif()


### PR DESCRIPTION
Currently, tests only work when run from the `${litehtml_root}/build` directory. This commit makes it possible to build and run tests in an arbitrary directory. In particular, this avoids errors when building `litebrowser-linux` with the `-DLITEHTML_BUILD_TESTING:BOOL=ON` switch.