### PR TITLE
Fix build error caused by non-const copy ctor of cairo_surface_wrapper

### DIFF
--- a/containers/cairo/cairo_images_cache.h
+++ b/containers/cairo/cairo_images_cache.h
@@ -11,7 +11,7 @@ class cairo_surface_wrapper
 	cairo_surface_t* surface;
 public:
 	cairo_surface_wrapper() : surface(nullptr) {}
-	cairo_surface_wrapper(cairo_surface_wrapper& v) : surface(v.surface)
+	cairo_surface_wrapper(const cairo_surface_wrapper& v) : surface(v.surface)
 	{
 		if(v.surface)
 		{


### PR DESCRIPTION
Detailed error context: 
containers/cairo/cairo_images_cache.h:64:11: note: in instantiation of template class 'std::__value_type<std::string, cairo_surface_wrapper>' requested here
                if(iter != m_images.end())

MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/__utility/pair.h:54:5: error: the parameter for this explicitly-defaulted copy constructor is const, but a member or base requires it to be non-const
    pair(pair const&) = default;