### PR TITLE
These strings are not modified, so pass by ref

### DIFF
--- a/include/litehtml/html_microsyntaxes.h
+++ b/include/litehtml/html_microsyntaxes.h
@@ -4,8 +4,8 @@
 namespace litehtml
 {
 
-bool html_parse_integer(string str, int& val);
-bool html_parse_non_negative_integer(string str, int& val);
+bool html_parse_integer(const string& str, int& val);
+bool html_parse_non_negative_integer(const string& str, int& val);
 
 enum html_dimension_type
 {
@@ -13,8 +13,8 @@ enum html_dimension_type
 	html_percentage
 };
 
-bool html_parse_dimension_value(string str, float& val, html_dimension_type& type);
-bool html_parse_nonzero_dimension_value(string str, float& val, html_dimension_type& type);
+bool html_parse_dimension_value(const string& str, float& val, html_dimension_type& type);
+bool html_parse_nonzero_dimension_value(const string& str, float& val, html_dimension_type& type);
 
 } // namespace litehtml
 

--- a/src/css_selector.cpp
+++ b/src/css_selector.cpp
@@ -264,9 +264,9 @@ struct an_b
 const size_t EOL = string::npos;
 
 // NOTE: "+ 5" is not valid, and strtol correctly fails to parse it
-bool to_int(string s, int& number)
+bool to_int(const string& s, int& number)
 {
-	if (s == "") return false;
+	if (s.empty()) return false;
 
 	const char* ptr = s.c_str();
 	char* end;

--- a/src/html_microsyntaxes.cpp
+++ b/src/html_microsyntaxes.cpp
@@ -4,7 +4,7 @@ namespace litehtml
 {
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-integers
-bool html_parse_integer(string str, int& val)
+bool html_parse_integer(const string& str, int& val)
 {
 	const char* ptr = str.c_str();
 	char* end;
@@ -16,7 +16,7 @@ bool html_parse_integer(string str, int& val)
 }
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-non-negative-integers
-bool html_parse_non_negative_integer(string str, int& val)
+bool html_parse_non_negative_integer(const string& str, int& val)
 {
 	int n = 0;
 	if (!html_parse_integer(str, n) || n < 0)
@@ -26,7 +26,7 @@ bool html_parse_non_negative_integer(string str, int& val)
 }
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-dimension-values
-bool html_parse_dimension_value(string str, float& result, html_dimension_type& type)
+bool html_parse_dimension_value(const string& str, float& result, html_dimension_type& type)
 {
 	// 1. Let input be the string being parsed.
 	// 2. Let position be a position variable for input, initially pointing at the start of input.
@@ -88,7 +88,7 @@ bool html_parse_dimension_value(string str, float& result, html_dimension_type& 
 }
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-non-zero-dimension-values
-bool html_parse_nonzero_dimension_value(string str, float& val, html_dimension_type& type)
+bool html_parse_nonzero_dimension_value(const string& str, float& val, html_dimension_type& type)
 {
 	float x;
 	html_dimension_type t;


### PR DESCRIPTION
Also use .empty() instead of equality.