### PR TITLE
Use parens in macro

### DIFF
--- a/src/encodings.cpp
+++ b/src/encodings.cpp
@@ -4,7 +4,7 @@
 
 #define out
 #define inout
-#define countof(a) int(sizeof(a)/sizeof(a[0]))
+#define countof(a) int(sizeof(a)/sizeof((a)[0]))
 
 namespace litehtml
 {


### PR DESCRIPTION
https://releases.llvm.org/17.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/macro-parentheses.html