### PR TITLE
{style} Prefer .empty() for readability

### DIFF
--- a/src/css_selector.cpp
+++ b/src/css_selector.cpp
@@ -152,7 +152,7 @@ css_attribute_selector parse_attribute_selector(const css_token& block)
 	// <wq-name>
 	skip_whitespace(tokens, index);
 	wq_name wq_name = parse_wq_name(tokens, index);
-	if (wq_name.name == "") return {};
+	if (wq_name.name.empty()) return {};
 
 	skip_whitespace(tokens, index);
 	if (index == (int)tokens.size()) // [name]
@@ -311,7 +311,7 @@ an_b parse_an_b(string s)
 	}
 
 	trim(str_b); // spaces after n are allowed: 2n + 3
-	if (str_b != "")
+	if (!str_b.empty())
 	{
 		if (str_b[0] == '+' || str_b[0] == '-')
 			while (is_whitespace(str_b[1])) str_b.erase(1, 1); // spaces after sign are allowed
@@ -559,7 +559,7 @@ css_element_selector::ptr parse_compound_selector(const css_token_vector& tokens
 	// <type-selector>?
 	wq_name wq_name = parse_type_selector(tokens, index);
 	selector->m_prefix = _id(wq_name.prefix);
-	selector->m_tag    = _id(wq_name.name != "" ? wq_name.name : "*");
+	selector->m_tag    = _id(!wq_name.name.empty() ? wq_name.name : "*");
 
 	// <subclass-selector>*
 	while (css_attribute_selector sel = parse_subclass_selector(tokens, index))
@@ -645,7 +645,7 @@ bool has_selector(const css_selector& selector, attr_select_type type, const str
 {
 	for (const auto& sel : selector.m_right.m_attrs)
 	{
-		if (sel.type == type && (name == "" || equal_i(_s(sel.name), name)))
+		if (sel.type == type && (name.empty() || equal_i(_s(sel.name), name)))
 			return true;
 	}
 	

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -68,12 +68,12 @@ document::ptr document::createFromString(
 	// Destroy GumboOutput
 	gumbo_destroy_output(&kGumboDefaultOptions, output);
 
-	if (master_styles != "")
+	if (!master_styles.empty())
 	{
 		doc->m_master_css.parse_css_stylesheet(master_styles, "", doc);
 		doc->m_master_css.sort_selectors();
 	}
-	if (user_styles != "")
+	if (!user_styles.empty())
 	{
 		doc->m_user_css.parse_css_stylesheet(user_styles, "", doc);
 		doc->m_user_css.sort_selectors();
@@ -96,7 +96,7 @@ document::ptr document::createFromString(
 		for (const auto& css : doc->m_css)
 		{
 			media_query_list_list::ptr media;
-			if (css.media != "")
+			if (!css.media.empty())
 			{
 				auto mq_list = parse_media_query_list(css.media, doc);
 				media = make_shared<media_query_list_list>();

--- a/src/encodings.cpp
+++ b/src/encodings.cpp
@@ -1718,7 +1718,7 @@ bool prescan_get_attribute(const string& str, inout int& index, out string& name
 
 	// 4.
 step_4:
-	if (str[index] == '=' && name != "")
+	if (str[index] == '=' && !name.empty())
 	{
 		increment(index, str);
 		goto process_value;

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -664,7 +664,7 @@ int html_tag::select_attribute(const css_attribute_selector& sel)
 		break;
 
 	case attribute_contains_string: // *=
-		if (sel.value != "" && contains(attr_value, sel.value))
+		if (!sel.value.empty() && contains(attr_value, sel.value))
 		{
 			return select_match;
 		}
@@ -672,14 +672,14 @@ int html_tag::select_attribute(const css_attribute_selector& sel)
 
 	// Attribute value is a whitespace-separated list of words, one of which is exactly sel.value
 	case attribute_contains_word: // ~=
-		if (sel.value != "" && contains(split_string(attr_value), sel.value))
+		if (!sel.value.empty() && contains(split_string(attr_value), sel.value))
 		{
 			return select_match;
 		}
 		break;
 
 	case attribute_starts_with_string: // ^=
-		if (sel.value != "" && match(attr_value, 0, sel.value))
+		if (!sel.value.empty() && match(attr_value, 0, sel.value))
 		{
 			return select_match;
 		}
@@ -695,7 +695,7 @@ int html_tag::select_attribute(const css_attribute_selector& sel)
 		break;
 
 	case attribute_ends_with_string: // $=
-		if (sel.value != "" && match(attr_value, -(int)sel.value.size(), sel.value))
+		if (!sel.value.empty() && match(attr_value, -(int)sel.value.size(), sel.value))
 		{
 			return select_match;
 		}
@@ -1044,7 +1044,7 @@ void litehtml::html_tag::draw_list_marker( uint_ptr hdc, const position& pos )
 	list_marker lm;
 
 	size img_size;
-	if (css().get_list_style_image() != "")
+	if (!css().get_list_style_image().empty())
 	{
 		lm.image   = css().get_list_style_image();
 		lm.baseurl = css().get_list_style_image_baseurl().c_str();

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -495,7 +495,7 @@ void style::parse_list_style(const css_token_vector& tokens, string baseurl, boo
 	// initial values:  https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#formal_definition
 	int type     = list_style_type_disc;
 	int position = list_style_position_outside;
-	string image = ""; // none
+	string image; // none
 
 	bool type_found = false;
 	bool position_found = false;


### PR DESCRIPTION
https://releases.llvm.org/17.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability/container-size-empty.html

(Also sneak in removal of a redundant initialization.)

Part of #336