### PR TITLE
Add support for the "appearance" CSS property

### DIFF
--- a/include/litehtml/css_properties.h
+++ b/include/litehtml/css_properties.h
@@ -22,6 +22,7 @@ namespace litehtml
 		white_space				m_white_space;
 		style_display			m_display;
 		visibility				m_visibility;
+		appearance				m_appearance;
 		box_sizing				m_box_sizing;
 		css_length				m_z_index;
 		vertical_align			m_vertical_align;
@@ -88,6 +89,7 @@ namespace litehtml
 				m_white_space(white_space_normal),
 				m_display(display_inline),
 				m_visibility(visibility_visible),
+				m_appearance(appearance_none),
 				m_box_sizing(box_sizing_content_box),
 				m_z_index(0),
 				m_vertical_align(va_baseline),
@@ -147,6 +149,9 @@ namespace litehtml
 
 		visibility get_visibility() const;
 		void set_visibility(visibility mVisibility);
+
+		appearance get_appearance() const;
+		void set_appearance(appearance mAppearance);
 
 		box_sizing get_box_sizing() const;
 		void set_box_sizing(box_sizing mBoxSizing);
@@ -319,6 +324,16 @@ namespace litehtml
 	inline void css_properties::set_visibility(visibility mVisibility)
 	{
 		m_visibility = mVisibility;
+	}
+
+	inline appearance css_properties::get_appearance() const
+	{
+		return m_appearance;
+	}
+
+	inline void css_properties::set_appearance(appearance mAppearance)
+	{
+		m_appearance = mAppearance;
 	}
 
 	inline box_sizing css_properties::get_box_sizing() const

--- a/include/litehtml/string_id.h
+++ b/include/litehtml/string_id.h
@@ -267,6 +267,7 @@ STRING_ID(
 	_overflow_,
 	_display_,
 	_visibility_,
+	_appearance_,
 	_box_sizing_,
 	_z_index_,
 	_float_,

--- a/include/litehtml/types.h
+++ b/include/litehtml/types.h
@@ -830,6 +830,27 @@ namespace litehtml
 		_baseline_type m_type;
 	};
 
+#define appearance_strings      "none;auto;menulist-button;textfield;button;checkbox;listbox;menulist;meter;progress-bar;push-button;radio;searchfield;slider-horizontal;square-button;textarea"
+
+	enum appearance
+	{
+		appearance_none,
+		appearance_auto,
+		appearance_menulist_button,
+		appearance_textfield,
+		appearance_button,
+		appearance_checkbox,
+		appearance_listbox,
+		appearance_menulist,
+		appearance_meter,
+		appearance_progress_bar,
+		appearance_push_button,
+		appearance_radio,
+		appearance_searchfield,
+		appearance_slider_horizontal,
+		appearance_square_button,
+		appearance_textarea,
+	};
 
 #define box_sizing_strings		"content-box;border-box"
 

--- a/src/css_properties.cpp
+++ b/src/css_properties.cpp
@@ -15,6 +15,7 @@ void litehtml::css_properties::compute(const html_tag* el, const document::ptr& 
 	m_visibility	 = (visibility)		  el->get_property<int>( _visibility_,		true,	visibility_visible,		 offset(m_visibility));
 	m_float			 = (element_float)	  el->get_property<int>( _float_,			false,	float_none,				 offset(m_float));
 	m_clear			 = (element_clear)	  el->get_property<int>( _clear_,			false,	clear_none,				 offset(m_clear));
+	m_appearance	 = (appearance)		  el->get_property<int>( _appearance_,		false,	appearance_none,		 offset(m_appearance));
 	m_box_sizing	 = (box_sizing)		  el->get_property<int>( _box_sizing_,		false,	box_sizing_content_box,	 offset(m_box_sizing));
 	m_overflow		 = (overflow)		  el->get_property<int>( _overflow_,		false,	overflow_visible,		 offset(m_overflow));
 	m_text_align	 = (text_align)		  el->get_property<int>( _text_align_,		true,	text_align_left,		 offset(m_text_align));
@@ -462,6 +463,7 @@ std::vector<std::tuple<litehtml::string, litehtml::string>> litehtml::css_proper
 	ret.emplace_back("overflow", index_value(m_overflow, overflow_strings));
 	ret.emplace_back("white_space", index_value(m_white_space, white_space_strings));
 	ret.emplace_back("visibility", index_value(m_visibility, visibility_strings));
+	ret.emplace_back("appearance", index_value(m_appearance, appearance_strings));
 	ret.emplace_back("box_sizing", index_value(m_box_sizing, box_sizing_strings));
 	ret.emplace_back("z_index", m_z_index.to_string());
 	ret.emplace_back("vertical_align", index_value(m_vertical_align, vertical_align_strings));

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -28,6 +28,7 @@ std::map<string_id, string> style::m_valid_values =
 	{ _float_, element_float_strings },
 	{ _clear_, element_clear_strings },
 	{ _overflow_, overflow_strings },
+	{ _appearance_, appearance_strings },
 	{ _box_sizing_, box_sizing_strings },
 
 	{ _text_align_, text_align_strings },
@@ -193,6 +194,7 @@ void style::add_property(string_id name, const css_token_vector& value, const st
 	case _position_:
 	case _float_:
 	case _clear_:
+	case _appearance_:
 	case _box_sizing_:
 	case _overflow_:
 


### PR DESCRIPTION
Because litehtml itself does not implement input widgets, this is simply a passthrough value to allow applications implementing input support to handle the property.

References:
- https://www.w3.org/TR/css-ui-4/#appearance-switching
- https://developer.mozilla.org/en-US/docs/Web/CSS/appearance

MDN references some non-standard values, as well as the `-webkit-appearance` and `-moz-appearance` vendor prefixes (the `-webkit` prefix is common enough that the W3 spec references it as well), but for this PR I opted to just handle the values directly referenced in the standard.

Please let me know if anything else is needed to get this merged!