### PR TITLE
Support for text-decoration CSS properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(HEADER_LITEHTML
 	include/litehtml/flex_item.h
 	include/litehtml/flex_line.h
 	include/litehtml/gradient.h
+	include/litehtml/font_description.h
 )
 
 set(PROJECT_LIB_VERSION ${PROJECT_MAJOR}.${PROJECT_MINOR}.0)
@@ -199,7 +200,7 @@ else ()
 	ExternalProject_Add(
 			litehtml-tests
 			GIT_REPOSITORY      https://github.com/litehtml/litehtml-tests.git
-			GIT_TAG             e90547605bda845c1b953232b1c2b3645928eac2
+			GIT_TAG             b746fd0df7f83d6aa2fea1cfee869459e8197970
 			SOURCE_DIR          "${CMAKE_BINARY_DIR}/litehtml-tests-src"
 			BINARY_DIR          "${CMAKE_BINARY_DIR}/litehtml-tests-build"
 			CMAKE_ARGS          -DLITEHTML_PATH=${CMAKE_CURRENT_SOURCE_DIR}

--- a/containers/cairo/container_cairo_pango.cpp
+++ b/containers/cairo/container_cairo_pango.cpp
@@ -30,11 +30,10 @@ container_cairo_pango::~container_cairo_pango()
 	cairo_destroy(m_temp_cr);
 }
 
-litehtml::uint_ptr container_cairo_pango::create_font(const char *faceName, int size, int weight, litehtml::font_style italic,
-													  unsigned int decoration, litehtml::font_metrics *fm)
+litehtml::uint_ptr container_cairo_pango::create_font(const litehtml::font_description& descr, const litehtml::document* doc, litehtml::font_metrics *fm)
 {
 	litehtml::string_vector tokens;
-	litehtml::split_string(faceName, tokens, ",");
+	litehtml::split_string(descr.family, tokens, ",");
 	std::string fonts;
 
 	for(auto& font : tokens)
@@ -60,32 +59,22 @@ litehtml::uint_ptr container_cairo_pango::create_font(const char *faceName, int 
 	}
 
 	PangoFontDescription *desc = pango_font_description_from_string (fonts.c_str());
-	pango_font_description_set_absolute_size(desc, size * PANGO_SCALE);
-	if(italic == litehtml::font_style_italic)
+	pango_font_description_set_absolute_size(desc, descr.size * PANGO_SCALE);
+	if(descr.style == litehtml::font_style_italic)
 	{
 		pango_font_description_set_style(desc, PANGO_STYLE_ITALIC);
 	} else
 	{
 		pango_font_description_set_style(desc, PANGO_STYLE_NORMAL);
 	}
-	PangoWeight fnt_weight;
-	if(weight >= 0 && weight < 150)			fnt_weight = PANGO_WEIGHT_THIN;
-	else if(weight >= 150 && weight < 250)	fnt_weight = PANGO_WEIGHT_ULTRALIGHT;
-	else if(weight >= 250 && weight < 350)	fnt_weight = PANGO_WEIGHT_LIGHT;
-	else if(weight >= 350 && weight < 450)	fnt_weight = PANGO_WEIGHT_NORMAL;
-	else if(weight >= 450 && weight < 550)	fnt_weight = PANGO_WEIGHT_MEDIUM;
-	else if(weight >= 550 && weight < 650)	fnt_weight = PANGO_WEIGHT_SEMIBOLD;
-	else if(weight >= 650 && weight < 750)	fnt_weight = PANGO_WEIGHT_BOLD;
-	else if(weight >= 750 && weight < 850)	fnt_weight = PANGO_WEIGHT_ULTRABOLD;
-	else fnt_weight = PANGO_WEIGHT_HEAVY;
 
-	pango_font_description_set_weight(desc, fnt_weight);
+	pango_font_description_set_weight(desc, (PangoWeight) descr.weight);
 
 	cairo_font* ret = nullptr;
 
 	if(fm)
 	{
-		fm->font_size = size;
+		fm->font_size = descr.size;
 
 		cairo_save(m_temp_cr);
 		PangoLayout *layout = pango_cairo_create_layout(m_temp_cr);
@@ -95,12 +84,12 @@ litehtml::uint_ptr container_cairo_pango::create_font(const char *faceName, int 
 		PangoFontMetrics *metrics = pango_context_get_metrics(context, desc, language);
 
 		fm->ascent = PANGO_PIXELS((double)pango_font_metrics_get_ascent(metrics));
-		fm->descent = PANGO_PIXELS((double)pango_font_metrics_get_descent(metrics));
 		fm->height = PANGO_PIXELS((double)pango_font_metrics_get_height(metrics));
+		fm->descent = fm->height - fm->ascent;
 		fm->x_height = fm->height;
-		fm->draw_spaces = (decoration != litehtml::font_decoration_none);
-		fm->sub_shift = size / 5;
-		fm->super_shift = size / 3;
+		fm->draw_spaces = (descr.decoration_line != litehtml::text_decoration_line_none);
+		fm->sub_shift = descr.size / 5;
+		fm->super_shift = descr.size / 3;
 
 		pango_layout_set_text(layout, "x", 1);
 
@@ -118,24 +107,60 @@ litehtml::uint_ptr container_cairo_pango::create_font(const char *faceName, int 
 		cairo_restore(m_temp_cr);
 
 		ret = new cairo_font;
-		ret->font		= desc;
-		ret->size		= size;
-		ret->strikeout 	= (decoration & litehtml::font_decoration_linethrough) != 0;
-		ret->underline	= (decoration & litehtml::font_decoration_underline) != 0;
-		ret->ascent     = fm->ascent;
-		ret->descent    = fm->descent;
+		ret->font				= desc;
+		ret->size				= descr.size;
+		ret->strikeout			= (descr.decoration_line & litehtml::text_decoration_line_line_through) != 0;
+		ret->underline			= (descr.decoration_line & litehtml::text_decoration_line_underline) != 0;
+		ret->overline			= (descr.decoration_line & litehtml::text_decoration_line_overline) != 0;
+		ret->ascent				= fm->ascent;
+		ret->descent			= fm->descent;
+		ret->decoration_color 	= descr.decoration_color;
+		ret->decoration_style	= descr.decoration_style;
 
-		ret->underline_thickness = pango_font_metrics_get_underline_thickness(metrics);
+		auto thinkness = descr.decoration_thickness;
+		if(!thinkness.is_predefined())
+		{
+			litehtml::css_length one_em(1.0, litehtml::css_units_em);
+			doc->cvt_units(one_em, *fm, 0);
+			doc->cvt_units(thinkness, *fm, (int) one_em.val());
+		}
+
+
 		ret->underline_position = -pango_font_metrics_get_underline_position(metrics);
+		if(thinkness.is_predefined())
+		{
+			ret->underline_thickness = pango_font_metrics_get_underline_thickness(metrics);
+		} else
+		{
+			ret->underline_thickness = (int)(thinkness.val() * PANGO_SCALE);
+		}
 		pango_quantize_line_geometry(&ret->underline_thickness, &ret->underline_position);
 		ret->underline_thickness = PANGO_PIXELS(ret->underline_thickness);
-		ret->underline_position = -1;//PANGO_PIXELS(ret->underline_position);
+		ret->underline_position = PANGO_PIXELS(ret->underline_position);
 
-		ret->strikethrough_thickness = pango_font_metrics_get_strikethrough_thickness(metrics);
 		ret->strikethrough_position = pango_font_metrics_get_strikethrough_position(metrics);
+		if(thinkness.is_predefined())
+		{
+			ret->strikethrough_thickness = pango_font_metrics_get_strikethrough_thickness(metrics);
+		} else
+		{
+			ret->strikethrough_thickness = (int)(thinkness.val() * PANGO_SCALE);
+		}
 		pango_quantize_line_geometry(&ret->strikethrough_thickness, &ret->strikethrough_position);
 		ret->strikethrough_thickness = PANGO_PIXELS(ret->strikethrough_thickness);
 		ret->strikethrough_position = PANGO_PIXELS(ret->strikethrough_position);
+
+		ret->overline_position = fm->ascent * PANGO_SCALE;
+		if(thinkness.is_predefined())
+		{
+			ret->overline_thickness = pango_font_metrics_get_underline_thickness(metrics);
+		} else
+		{
+			ret->overline_thickness = (int)(thinkness.val() * PANGO_SCALE);
+		}
+		pango_quantize_line_geometry(&ret->overline_thickness, &ret->overline_position);
+		ret->overline_thickness = PANGO_PIXELS(ret->overline_thickness);
+		ret->overline_position = PANGO_PIXELS(ret->overline_position);
 
 		g_object_unref(layout);
 		pango_font_metrics_unref(metrics);
@@ -176,6 +201,170 @@ int container_cairo_pango::text_width(const char *text, litehtml::uint_ptr hFont
 	return (int) x_width;
 }
 
+enum class draw_type
+{
+	DRAW_OVERLINE,
+	DRAW_STRIKETHROUGH,
+	DRAW_UNDERLINE
+};
+
+static inline void draw_single_line(cairo_t* cr, int x, int y, int width, int thickness, draw_type type)
+{
+	double top;
+	switch (type)
+	{
+	case draw_type::DRAW_UNDERLINE:
+		top = y + (double)thickness / 2.0;
+		break;
+	case draw_type::DRAW_OVERLINE:
+		top = y - (double)thickness / 2.0;
+		break;
+	case draw_type::DRAW_STRIKETHROUGH:
+		top = y + 0.5;
+		break;
+	default:
+		top = y;
+		break;
+	}
+	cairo_move_to(cr, x, top);
+	cairo_line_to(cr, x + width, top);
+}
+
+static void draw_solid_line(cairo_t* cr, int x, int y, int width, int thickness, draw_type type, litehtml::web_color& color)
+{
+	draw_single_line(cr, x, y, width, thickness, type);
+
+	cairo_set_source_rgba(cr, 	(double) color.red / 255.0,
+								(double) color.green / 255.0,
+								(double) color.blue / 255.0,
+								(double) color.alpha / 255.0);
+	cairo_set_line_width(cr, thickness);
+	cairo_stroke(cr);
+}
+
+static void draw_dotted_line(cairo_t* cr, int x, int y, int width, int thickness, draw_type type, litehtml::web_color& color)
+{
+	draw_single_line(cr, x, y, width, thickness, type);
+
+	std::array<double, 2> dashes {0, thickness * 2.0};
+	if(thickness == 1) dashes[1] += thickness / 2.0;
+	cairo_set_line_width(cr, thickness);
+	cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+	cairo_set_dash(cr, dashes.data(), 2, x);
+
+	cairo_set_source_rgba(cr, 	(double) color.red / 255.0,
+								(double) color.green / 255.0,
+								(double) color.blue / 255.0,
+								(double) color.alpha / 255.0);
+	cairo_stroke(cr);
+}
+
+static void draw_dashed_line(cairo_t* cr, int x, int y, int width, int thickness, draw_type type, litehtml::web_color& color)
+{
+	draw_single_line(cr, x, y, width, thickness, type);
+
+	std::array<double, 2> dashes {thickness * 2.0, thickness * 3.0};
+	cairo_set_line_width(cr, thickness);
+	cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+	cairo_set_dash(cr, dashes.data(), 2, x);
+
+	cairo_set_source_rgba(cr, 	(double) color.red / 255.0,
+								(double) color.green / 255.0,
+								(double) color.blue / 255.0,
+								(double) color.alpha / 255.0);
+	cairo_stroke(cr);
+}
+
+static void draw_wavy_line(cairo_t* cr, int x, int y, int width, int thickness, draw_type type, litehtml::web_color& color)
+{
+	double h_pad = 1.0;
+	int brush_height = (int) thickness * 3 + h_pad * 2;
+	int brush_width = brush_height * 2 - 2 * thickness;
+
+	double top;
+	switch (type)
+	{
+	case draw_type::DRAW_UNDERLINE:
+		top = y + (double)brush_height / 2.0;
+		break;
+	case draw_type::DRAW_OVERLINE:
+		top = y - (double)brush_height / 2.0;
+		break;
+	default:
+		top = y;
+		break;
+	}
+
+	cairo_surface_t* brush_surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, brush_width, brush_height);
+	cairo_t* brush_cr = cairo_create(brush_surface);
+
+	cairo_set_source_rgba(brush_cr, (double) color.red / 255.0,
+									(double) color.green / 255.0,
+									(double) color.blue / 255.0,
+									(double) color.alpha / 255.0);
+	cairo_set_line_width(brush_cr, thickness);
+	double w = thickness / 2.0;
+	cairo_move_to(brush_cr, 0, brush_height - (double) thickness / 2.0 - h_pad);
+	cairo_line_to(brush_cr, w, brush_height - (double) thickness / 2.0 - h_pad);
+	cairo_line_to(brush_cr, brush_width / 2.0 - w, (double) thickness / 2.0 + h_pad);
+	cairo_line_to(brush_cr, brush_width / 2.0 + w, (double) thickness / 2.0 + h_pad);
+	cairo_line_to(brush_cr, brush_width - w, brush_height - (double) thickness / 2.0 - h_pad);
+	cairo_line_to(brush_cr, brush_width, brush_height - (double) thickness / 2.0 - h_pad);
+	cairo_stroke(brush_cr);
+	cairo_destroy(brush_cr);
+
+	cairo_pattern_t *pattern = cairo_pattern_create_for_surface(brush_surface);
+	cairo_pattern_set_extend(pattern, CAIRO_EXTEND_REPEAT);
+	cairo_matrix_t patterm_matrix;
+	cairo_matrix_init_translate(&patterm_matrix, 0, -top + brush_height / 2.0);
+	cairo_pattern_set_matrix(pattern, &patterm_matrix);
+	cairo_set_source(cr, pattern);
+
+	cairo_set_line_width(cr, brush_height);
+	cairo_move_to(cr, x, top);
+    cairo_line_to(cr, x + width, top);
+    cairo_stroke(cr);
+
+	cairo_pattern_destroy(pattern);
+	cairo_surface_destroy(brush_surface);
+}
+
+static void draw_double_line(cairo_t* cr, int x, int y, int width, int thickness, draw_type type, litehtml::web_color& color)
+{
+	cairo_set_line_width(cr, thickness);
+	double top1;
+	double top2;
+	switch (type)
+	{
+	case draw_type::DRAW_UNDERLINE:
+		top1 = y + (double)thickness / 2.0;
+		top2 = top1 + (double)thickness + (double)thickness / 2.0 + 0.5;
+		break;
+	case draw_type::DRAW_OVERLINE:
+		top1 = y - (double)thickness / 2.0;
+		top2 = top1 - (double)thickness - (double)thickness / 2.0 - 0.5;
+		break;
+	case draw_type::DRAW_STRIKETHROUGH:
+		top1 = y  - (double)thickness + 0.5;
+		top2 = y  + (double)thickness + 0.5;
+	break;
+	default:
+		top1 = y;
+		top2 = y;
+	break;
+	}
+	cairo_move_to(cr, x, top1);
+	cairo_line_to(cr, x + width, top1);
+	cairo_stroke(cr);
+	cairo_move_to(cr, x, top2);
+	cairo_line_to(cr, x + width, top2);
+	cairo_set_source_rgba(cr, 	(double) color.red / 255.0,
+								(double) color.green / 255.0,
+								(double) color.blue / 255.0,
+								(double) color.alpha / 255.0);
+	cairo_stroke(cr);
+}
+
 void container_cairo_pango::draw_text(litehtml::uint_ptr hdc, const char *text, litehtml::uint_ptr hFont,
 									  litehtml::web_color color, const litehtml::position &pos)
 {
@@ -186,6 +375,8 @@ void container_cairo_pango::draw_text(litehtml::uint_ptr hdc, const char *text, 
 	apply_clip(cr);
 
 	set_color(cr, color);
+
+	litehtml::web_color decoration_color = color;
 
 	PangoLayout *layout = pango_cairo_create_layout(cr);
 	pango_layout_set_font_description (layout, fnt->font);
@@ -212,24 +403,37 @@ void container_cairo_pango::draw_text(litehtml::uint_ptr hdc, const char *text, 
 
 	int tw = 0;
 
-	if(fnt->underline || fnt->strikeout)
+	if(fnt->underline || fnt->strikeout || fnt->overline)
 	{
 		tw = text_width(text, hFont);
 	}
 
+	if(!fnt->decoration_color.is_current_color)
+	{
+		decoration_color = fnt->decoration_color;
+	}
+
+	std::array<decltype(&draw_solid_line), litehtml::text_decoration_style_max> draw_funcs {
+		draw_solid_line,	// text_decoration_style_solid
+		draw_double_line,	// text_decoration_style_double
+		draw_dotted_line,	// text_decoration_style_dotted
+		draw_dashed_line,	// text_decoration_style_dashed
+		draw_wavy_line,		// text_decoration_style_wavy
+	};
+
 	if(fnt->underline)
 	{
-		cairo_set_line_width(cr, fnt->underline_thickness);
-		cairo_move_to(cr, x, pos.top() + text_baseline - fnt->underline_position + 0.5);
-		cairo_line_to(cr, x + tw, pos.top() + text_baseline - fnt->underline_position + 0.5);
-		cairo_stroke(cr);
+		draw_funcs[fnt->decoration_style](cr, x, pos.top() + text_baseline + fnt->underline_position, tw, fnt->underline_thickness, draw_type::DRAW_UNDERLINE, decoration_color);
 	}
+
 	if(fnt->strikeout)
 	{
-		cairo_set_line_width(cr, fnt->strikethrough_thickness);
-		cairo_move_to(cr, x, pos.top() + text_baseline - fnt->strikethrough_position - 0.5);
-		cairo_line_to(cr, x + tw, pos.top() + text_baseline - fnt->strikethrough_position - 0.5);
-		cairo_stroke(cr);
+		draw_funcs[fnt->decoration_style](cr, x, pos.top() + text_baseline - fnt->strikethrough_position, tw, fnt->strikethrough_thickness, draw_type::DRAW_STRIKETHROUGH, decoration_color);
+	}
+
+	if(fnt->overline)
+	{
+		draw_funcs[fnt->decoration_style](cr, x, pos.top() + text_baseline - fnt->overline_position, tw, fnt->overline_thickness, draw_type::DRAW_OVERLINE, decoration_color);
 	}
 
 	cairo_restore(cr);

--- a/containers/cairo/container_cairo_pango.h
+++ b/containers/cairo/container_cairo_pango.h
@@ -14,12 +14,17 @@ struct cairo_font
 	int size;
 	bool underline;
 	bool strikeout;
+	bool overline;
 	int ascent;
 	int descent;
 	int underline_thickness;
 	int underline_position;
 	int strikethrough_thickness;
 	int strikethrough_position;
+	int overline_thickness;
+	int overline_position;
+	int decoration_style;
+	litehtml::web_color decoration_color;
 };
 
 class container_cairo_pango : public container_cairo
@@ -30,7 +35,7 @@ class container_cairo_pango : public container_cairo
 public:
 	container_cairo_pango();
 	~container_cairo_pango() override;
-	litehtml::uint_ptr create_font(const char* faceName, int size, int weight, litehtml::font_style italic, unsigned int decoration, litehtml::font_metrics* fm) override;
+	litehtml::uint_ptr create_font(const litehtml::font_description& descr, const litehtml::document* doc, litehtml::font_metrics* fm) override;
 	void delete_font(litehtml::uint_ptr hFont) override;
 	int text_width(const char* text, litehtml::uint_ptr hFont) override;
 	void draw_text(litehtml::uint_ptr hdc, const char* text, litehtml::uint_ptr hFont, litehtml::web_color color, const litehtml::position& pos) override;

--- a/include/litehtml/css_properties.h
+++ b/include/litehtml/css_properties.h
@@ -64,7 +64,10 @@ namespace litehtml
 		string					m_font_family;
 		css_length				m_font_weight;
 		font_style				m_font_style;
-		string					m_text_decoration;
+		int						m_text_decoration_line = text_decoration_line_none;
+		text_decoration_style	m_text_decoration_style = text_decoration_style_solid;
+		css_length				m_text_decoration_thickness;
+		web_color				m_text_decoration_color;
 		font_metrics			m_font_metrics;
 		text_transform			m_text_transform;
 		web_color				m_color;
@@ -276,6 +279,11 @@ namespace litehtml
 
 		int get_order() const;
 		void set_order(int order);
+
+		int get_text_decoration_line() const;
+		text_decoration_style get_text_decoration_style() const;
+		const css_length& get_text_decoration_thickness() const;
+		const web_color& get_text_decoration_color() const;
 	};
 
 	inline element_position css_properties::get_position() const
@@ -695,6 +703,26 @@ namespace litehtml
 	inline void css_properties::set_order(int order)
 	{
 		m_order = order;
+	}
+
+	inline int css_properties::get_text_decoration_line() const
+	{
+		return m_text_decoration_line;
+	}
+
+	inline text_decoration_style css_properties::get_text_decoration_style() const
+	{
+		return m_text_decoration_style;
+	}
+
+	inline const css_length& css_properties::get_text_decoration_thickness() const
+	{
+		return m_text_decoration_thickness;
+	}
+
+	inline const web_color& css_properties::get_text_decoration_color() const
+	{
+		return m_text_decoration_color;
 	}
 }
 

--- a/include/litehtml/document.h
+++ b/include/litehtml/document.h
@@ -5,6 +5,8 @@
 #include "types.h"
 #include "master_css.h"
 #include "encodings.h"
+#include "font_description.h"
+
 typedef struct GumboInternalOutput GumboOutput;
 
 namespace litehtml
@@ -16,7 +18,7 @@ namespace litehtml
 		string	text;
 		string	baseurl;
 		string	media;
-		
+
 		css_text() = default;
 
 		css_text(const char* txt, const char* url, const char* media_str)
@@ -73,7 +75,7 @@ namespace litehtml
 
 		document_container*				container()	{ return m_container; }
 		document_mode					mode() const { return m_mode; }
-		uint_ptr						get_font(const char* name, int size, const char* weight, const char* style, const char* decoration, font_metrics* fm);
+		uint_ptr						get_font(const font_description& descr, font_metrics* fm);
 		int								render(int max_width, render_type rt = render_all);
 		void							draw(uint_ptr hdc, int x, int y, const position* clip);
 		web_color						get_def_color()	{ return m_def_color; }
@@ -109,9 +111,9 @@ namespace litehtml
 			document_container*  container,
 			const string&        master_styles = litehtml::master_css,
 			const string&        user_styles = "");
-	
+
 	private:
-		uint_ptr	add_font(const char* name, int size, const char* weight, const char* style, const char* decoration, font_metrics* fm);
+		uint_ptr	add_font(const font_description& descr, font_metrics* fm);
 
 		GumboOutput* parse_html(estring str);
 		void create_node(void* gnode, elements_list& elements, bool parseTextNode);

--- a/include/litehtml/document_container.h
+++ b/include/litehtml/document_container.h
@@ -7,6 +7,7 @@
 #include "background.h"
 #include "borders.h"
 #include "element.h"
+#include "font_description.h"
 #include <memory>
 #include <functional>
 
@@ -22,7 +23,7 @@ namespace litehtml
 		int				index;
 		uint_ptr		font;
 	};
-	
+
 	enum mouse_event
 	{
 		mouse_event_enter,
@@ -33,7 +34,7 @@ namespace litehtml
 	class document_container
 	{
 	public:
-		virtual litehtml::uint_ptr	create_font(const char* faceName, int size, int weight, litehtml::font_style italic, unsigned int decoration, litehtml::font_metrics* fm) = 0;
+		virtual litehtml::uint_ptr	create_font(const font_description& descr, const document* doc, litehtml::font_metrics* fm) = 0;
 		virtual void				delete_font(litehtml::uint_ptr hFont) = 0;
 		virtual int					text_width(const char* text, litehtml::uint_ptr hFont) = 0;
 		virtual void				draw_text(litehtml::uint_ptr hdc, const char* text, litehtml::uint_ptr hFont, litehtml::web_color color, const litehtml::position& pos) = 0;

--- a/include/litehtml/font_description.h
+++ b/include/litehtml/font_description.h
@@ -1,0 +1,39 @@
+#ifndef LITEHTML_FONT_DESCRIPTION
+#define LITEHTML_FONT_DESCRIPTION
+
+#include <string>
+#include "types.h"
+#include "css_length.h"
+#include "web_color.h"
+
+namespace litehtml
+{
+	struct font_description
+	{
+		std::string				family;	// Font Family
+		int						size = 0;	// Font size
+		font_style				style = font_style_normal;	// Font stype, see the enum font_style
+		int						weight;	// Font weight.
+		int						decoration_line = text_decoration_line_none;	// Decoration line. A bitset of flags of the enum text_decoration_line
+		css_length				decoration_thickness;	// Decoration line thickness in pixels. See predefined values in enumtext_decoration_thickness
+		text_decoration_style	decoration_style = text_decoration_style_solid;	// Decoration line style. See enum text_decoration_style
+		web_color				decoration_color = web_color::current_color;	// Decoration line color
+
+		std::string	hash() const
+		{
+			std::string out;
+			out += family;
+			out += ":sz=" + std::to_string(size);
+			out += ":st=" + std::to_string(style);
+			out += ":w=" + std::to_string(weight);
+			out += ":dl=" + std::to_string(decoration_line);
+			out += ":dt=" + decoration_thickness.to_string();
+			out += ":ds=" + std::to_string(decoration_style);
+			out += ":dc=" + decoration_color.to_string();
+
+			return out;
+		}
+	};
+}
+
+#endif

--- a/include/litehtml/string_id.h
+++ b/include/litehtml/string_id.h
@@ -252,6 +252,10 @@ STRING_ID(
 	_font_size_,
 	_line_height_,
 	_text_decoration_,
+	_text_decoration_style_,
+	_text_decoration_line_,
+	_text_decoration_color_,
+	_text_decoration_thickness_,
 
 	_white_space_,
 	_text_align_,

--- a/include/litehtml/style.h
+++ b/include/litehtml/style.h
@@ -28,7 +28,7 @@ namespace litehtml
 		bool m_has_var   = false; // css_token_vector, parsing is delayed because of var()
 
 		property_value() {}
-		template<class T> property_value(const T& val, bool important, bool has_var = false) 
+		template<class T> property_value(const T& val, bool important, bool has_var = false)
 			: base(val), m_important(important), m_has_var(has_var) {}
 	};
 
@@ -73,26 +73,29 @@ namespace litehtml
 		void parse_keyword_comma_list(string_id name, const css_token_vector& tokens, bool important);
 		void parse_background_position(const css_token_vector& tokens, bool important);
 		void parse_background_size(const css_token_vector& tokens, bool important);
-		
+
 		void parse_border(const css_token_vector& tokens, bool important, document_container* container);
 		void parse_border_side(string_id name, const css_token_vector& tokens, bool important, document_container* container);
 		void parse_border_radius(const css_token_vector& tokens, bool important);
-		
+
 		bool parse_list_style_image(const css_token& tok, string& url);
 		void parse_list_style(const css_token_vector& tokens, string baseurl, bool important);
 
 		void parse_font(css_token_vector tokens, bool important);
-		
+		void parse_text_decoration(const css_token_vector& tokens, bool important, document_container* container);
+		bool parse_text_decoration_color(const css_token& token, bool important, document_container* container);
+		void parse_text_decoration_line(const css_token_vector& tokens, bool important);
+
 		void parse_flex_flow(const css_token_vector& tokens, bool important);
 		void parse_flex(const css_token_vector& tokens, bool important);
 		void parse_align_self(string_id name, const css_token_vector& tokens, bool important);
-		
+
 		void add_parsed_property(string_id name, const property_value& propval);
 		void add_length_property(string_id name, css_token val, string keywords, int options, bool important);
 		template<class T> void add_four_properties(string_id top_name, T val[4], int n, bool important);
 		void remove_property(string_id name, bool important);
 	};
-	
+
 	bool parse_url(const css_token& token, string& url);
 	bool parse_length(const css_token& tok, css_length& length, int options, string keywords = "");
 	bool parse_angle(const css_token& tok, float& angle, bool percents_allowed = false);

--- a/include/litehtml/types.h
+++ b/include/litehtml/types.h
@@ -50,10 +50,36 @@ namespace litehtml
 		limited_quirks_mode
 	};
 
-	const unsigned int font_decoration_none			= 0x00;
-	const unsigned int font_decoration_underline	= 0x01;
-	const unsigned int font_decoration_linethrough	= 0x02;
-	const unsigned int font_decoration_overline		= 0x04;
+	#define  style_text_decoration_line_strings		"none;underline;overline;line-through"
+
+	enum text_decoration_line
+	{
+		text_decoration_line_none			= 0x00,
+		text_decoration_line_underline		= 0x01,
+		text_decoration_line_overline		= 0x02,
+		text_decoration_line_line_through	= 0x04,
+	};
+
+	#define  style_text_decoration_style_strings	"solid;double;dotted;dashed;wavy"
+
+	enum text_decoration_style
+	{
+		text_decoration_style_solid,
+		text_decoration_style_double,
+		text_decoration_style_dotted,
+		text_decoration_style_dashed,
+		text_decoration_style_wavy,
+		text_decoration_style_max,
+	};
+
+	#define  style_text_decoration_thickness_strings	"auto;from-font"
+
+	enum text_decoration_thickness
+	{
+		text_decoration_thickness_auto,
+		text_decoration_thickness_from_font,
+	};
+
 
 	using byte = unsigned char;
 	using ucode_t = unsigned int;

--- a/src/css_properties.cpp
+++ b/src/css_properties.cpp
@@ -1,6 +1,8 @@
 #include "html.h"
 #include "css_properties.h"
 #include <cmath>
+#include <set>
+#include <sstream>
 
 #define offset(member) ((uint_ptr)&this->member - (uint_ptr)this)
 //#define offset(func)	[](const css_properties& css) { return css.func; }
@@ -361,6 +363,28 @@ void litehtml::css_properties::compute_font(const html_tag* el, const document::
 	m_font_style		= (font_style) el->get_property<int>(       _font_style_,		true, font_style_normal,							offset(m_font_style));
 	m_text_decoration	=              el->get_property<string>(    _text_decoration_,	true, "none",										offset(m_text_decoration));
 
+  // Merge parent text decoration with child text decoration
+  if (el->parent())
+  {
+    auto parent_text_decoration = el->parent()->css().m_text_decoration;
+    if (!parent_text_decoration.empty() && !m_text_decoration.empty())
+    {
+      std::set<string> wordSet;
+      std::istringstream stream(parent_text_decoration + " " + m_text_decoration);
+      std::string temp;
+
+      while (stream >> temp) wordSet.insert(temp);
+      if (wordSet.size() > 1)
+      {
+        wordSet.erase("none");
+      }
+      m_text_decoration = "";
+      for (const auto& word : wordSet) {
+        m_text_decoration += word + " ";
+      }
+    }
+  }
+  
 	m_font = doc->get_font(
 		m_font_family.c_str(),
 		font_size,


### PR DESCRIPTION
Supported properties:
* text-decoration (as shorthand for other text-decoration properties)
* text-decoration-color
* text-decoration-line
* text-decoration-style
* text-decoration-thickness

Changes in the container::create_font:
```litehtml::uint_ptr create_font(const font_description& descr, const document* doc, litehtml::font_metrics* fm);```

All font parameters are moved to the ```font_description``` structure.