### PR TITLE
Some small fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ else ()
 	ExternalProject_Add(
 			litehtml-tests
 			GIT_REPOSITORY      https://github.com/litehtml/litehtml-tests.git
-			GIT_TAG             e1a99fd8b84a285bbf0ab4978bcada12cecf4240
+			GIT_TAG             81e4d257f2701556385e91db5d18567ff29ad75d
 			SOURCE_DIR          "${CMAKE_BINARY_DIR}/litehtml-tests-src"
 			BINARY_DIR          "${CMAKE_BINARY_DIR}/litehtml-tests-build"
 			CMAKE_ARGS          -DLITEHTML_PATH=${CMAKE_CURRENT_SOURCE_DIR}

--- a/include/litehtml/element.h
+++ b/include/litehtml/element.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <tuple>
 #include <list>
+#include "litehtml/types.h"
 #include "stylesheet.h"
 #include "css_properties.h"
 
@@ -154,7 +155,9 @@ namespace litehtml
 
 	inline bool litehtml::element::in_normal_flow() const
 	{
-		if(css().get_position() != element_position_absolute && css().get_display() != display_none)
+		if(css().get_position() != element_position_absolute &&
+		   css().get_display() != display_none &&
+		   css().get_position() != element_position_fixed)
 		{
 			return true;
 		}

--- a/include/litehtml/render_item.h
+++ b/include/litehtml/render_item.h
@@ -348,7 +348,8 @@ namespace litehtml
                    m_element->css().get_float() == float_none &&
                    m_margins.top >= 0 &&
 				   !is_flex_item() &&
-                   !is_root();
+                   !is_root() &&
+                   css().get_position() != element_position_fixed;
         }
 
         bool collapse_bottom_margin() const
@@ -358,7 +359,8 @@ namespace litehtml
                    m_element->in_normal_flow() &&
                    m_element->css().get_float() == float_none &&
                    m_margins.bottom >= 0 &&
-                   !is_root();
+                   !is_root() &&
+                   css().get_position() != element_position_fixed;
         }
 
         bool is_visible() const

--- a/include/litehtml/render_item.h
+++ b/include/litehtml/render_item.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <list>
 #include <tuple>
+#include "html.h"
 #include "types.h"
 #include "line_box.h"
 #include "table.h"
@@ -349,7 +350,7 @@ namespace litehtml
                    m_margins.top >= 0 &&
 				   !is_flex_item() &&
                    !is_root() &&
-                   css().get_position() != element_position_fixed;
+                   !is_one_of(css().get_overflow(), overflow_hidden, overflow_scroll, overflow_auto);
         }
 
         bool collapse_bottom_margin() const
@@ -360,7 +361,7 @@ namespace litehtml
                    m_element->css().get_float() == float_none &&
                    m_margins.bottom >= 0 &&
                    !is_root() &&
-                   css().get_position() != element_position_fixed;
+                   !is_one_of(css().get_overflow(), overflow_hidden, overflow_scroll, overflow_auto);
         }
 
         bool is_visible() const

--- a/src/render_item.cpp
+++ b/src/render_item.cpp
@@ -46,7 +46,6 @@ int litehtml::render_item::render(int x, int y, const containing_block_context& 
 	if(src_el()->is_block_formatting_context() || ! fmt_ctx)
 	{
 		formatting_context fmt;
-		fmt.push_position(content_left, content_top);
 		ret = _render(x, y, containing_block_size, &fmt, second_pass);
 		fmt.apply_relative_shift(containing_block_size);
 	} else


### PR DESCRIPTION
Fixes:
1. Incorrect text position in floating elements with negative ```margin-left```.
2. Disable top/bottom margins collapse for elements with ```position:fixed```