### PR TITLE
media_query: add match for screen

### DIFF
--- a/src/media_query.cpp
+++ b/src/media_query.cpp
@@ -126,6 +126,8 @@ trilean media_query::check(const media_features& features) const
 		result = False;
 	else if (m_media_type == media_type_unknown)
 		result = False;
+	else if (m_media_type == media_type_screen)
+		result = True;
 	else if (m_media_type == media_type_all)
 		result = True;
 	else


### PR DESCRIPTION
For #359, to match media queries that specify `screen` type (as opposed to `print`), such as Wikipedia.

According to the linked [media queries doc](https://drafts.csswg.org/mediaqueries/#media-types), `screen` should be:
> Matches all devices that aren’t matched by [print](https://drafts.csswg.org/mediaqueries/#valdef-media-print).

And `print` is:
> Matches printers, and devices intended to reproduce a printed display, such as a web browser showing a document in “Print Preview”.

So either one or the other should be matched. Screenshots and example HTML are in the original issue (#359).