### PR TITLE
Allow building with Clang using MSVC ABI

### DIFF
--- a/src/gumbo/CMakeLists.txt
+++ b/src/gumbo/CMakeLists.txt
@@ -58,7 +58,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     PUBLIC_HEADER "${HEADER_GUMBO}"
 )
 
-if (MSVC)
+if (MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
     target_include_directories(${PROJECT_NAME} PRIVATE visualc/include)
 endif()
 


### PR DESCRIPTION
The official LLVM build of Clang is using the MSVC ABI, and if you are using clang.exe and not clang-cl.exe you get the GNU command line interface.

CMake would not set the MSVC variable, but the CMAKE_CXX_SIMULATE_ID as "MSVC". Since clang.exe is targeting the MSVC ABI it needs the build support the MSVC has.