### PR TITLE
Improve flex layout free space distribution

### DIFF
--- a/include/litehtml/flex_item.h
+++ b/include/litehtml/flex_item.h
@@ -15,10 +15,13 @@ namespace litehtml
 	{
 	public:
 		std::shared_ptr<render_item> el;
+
+		// All sizes should be interpreted as outer/margin-box sizes.
 		pixel_t base_size;
 		pixel_t min_size;
 		def_value<pixel_t> max_size;
-		pixel_t main_size;
+		pixel_t main_size; // Holds the outer hypothetical main size before distribute_free_space, and the used outer main size after.
+
 		int grow;
 		int shrink;
 		pixel_t scaled_flex_shrink_factor;

--- a/include/litehtml/flex_item.h
+++ b/include/litehtml/flex_item.h
@@ -8,6 +8,14 @@ namespace litehtml
 {
 	class flex_line;
 
+	enum flex_clamp_state
+	{
+		flex_clamp_state_unclamped,
+		flex_clamp_state_inflexible,
+		flex_clamp_state_min_violation,
+		flex_clamp_state_max_violation
+	};
+
 	/**
 	 * Base class for flex item
 	 */
@@ -25,13 +33,18 @@ namespace litehtml
 		int grow;
 		int shrink;
 		pixel_t scaled_flex_shrink_factor;
+
 		bool frozen;
+		flex_clamp_state clamp_state;
+
 		int order;
 		int src_order;
+
 		def_value<pixel_t> auto_margin_main_start;
 		def_value<pixel_t> auto_margin_main_end;
 		bool auto_margin_cross_start;
 		bool auto_margin_cross_end;
+
 		flex_align_items align;
 
 		explicit flex_item(std::shared_ptr<render_item> &_el) :
@@ -44,6 +57,7 @@ namespace litehtml
 				shrink(0),
 				scaled_flex_shrink_factor(0),
 				frozen(false),
+				clamp_state(flex_clamp_state_unclamped),
 				order(0),
 				src_order(0),
 				auto_margin_main_start(0),

--- a/include/litehtml/flex_line.h
+++ b/include/litehtml/flex_line.h
@@ -12,11 +12,9 @@ namespace litehtml
 		public:
 		std::list<std::shared_ptr<flex_item>> items;
 		pixel_t cross_start;	// for row direction: top. for column direction: left
-		pixel_t main_size;		// sum of all items main size
+		pixel_t main_size;		// sum of all items main size, initially the sum of hypothetical main sizes
 		pixel_t cross_size;		// sum of all items cross size
 		pixel_t base_size;
-		int total_grow;
-		int total_shrink;
 		int num_auto_margin_main_start;		// number of items with auto margin left/top
 		int num_auto_margin_main_end;		// number of items with auto margin right/bottom
 		baseline first_baseline;
@@ -29,8 +27,6 @@ namespace litehtml
 				main_size(0),
 				cross_size(0),
 				base_size(0),
-				total_grow(0),
-				total_shrink(0),
 				num_auto_margin_main_start(0),
 				num_auto_margin_main_end(0),
 				first_baseline(),

--- a/include/litehtml/flex_line.h
+++ b/include/litehtml/flex_line.h
@@ -50,6 +50,9 @@ namespace litehtml
 									  formatting_context *fmt_ctx);
 	protected:
 		void distribute_free_space(pixel_t container_main_size);
+		void distribute_free_space_grow(pixel_t container_main_size);
+		void distribute_free_space_shrink(pixel_t container_main_size);
+		bool fix_min_max_violations();
 	};
 }
 

--- a/src/flex_item.cpp
+++ b/src/flex_item.cpp
@@ -147,12 +147,12 @@ void litehtml::flex_item_row_direction::direction_specific_init(const litehtml::
 	} else
 	{
 		min_size = el->css().get_min_width().calc_percent(self_size.render_width) +
-				   el->content_offset_width();
+				   el->render_offset_width();
 	}
 	if (!el->css().get_max_width().is_predefined())
 	{
 		max_size = el->css().get_max_width().calc_percent(self_size.render_width) +
-				   el->content_offset_width();
+				   el->render_offset_width();
 	}
 	bool flex_basis_predefined = el->css().get_flex_basis().is_predefined();
 	int predef = flex_basis_auto;
@@ -331,12 +331,12 @@ void litehtml::flex_item_column_direction::direction_specific_init(const litehtm
 	} else
 	{
 		min_size = el->css().get_min_height().calc_percent(self_size.height) +
-				   el->content_offset_height();
+				   el->render_offset_height();
 	}
 	if (!el->css().get_max_height().is_predefined())
 	{
 		max_size = el->css().get_max_height().calc_percent(self_size.height) +
-				   el->content_offset_width();
+				   el->render_offset_height();
 	}
 
 	bool flex_basis_predefined = el->css().get_flex_basis().is_predefined();
@@ -362,7 +362,7 @@ void litehtml::flex_item_column_direction::direction_specific_init(const litehtm
 		{
 			case flex_basis_auto:
 				base_size = el->css().get_height().calc_percent(self_size.height) +
-							el->content_offset_height();
+							el->render_offset_height();
 				break;
 			case flex_basis_max_content:
 			case flex_basis_fit_content:
@@ -382,7 +382,7 @@ void litehtml::flex_item_column_direction::direction_specific_init(const litehtm
 			if(self_size.height.type == containing_block_context::cbc_value_type_absolute)
 			{
 				base_size = el->css().get_flex_basis().calc_percent(self_size.height) +
-							el->content_offset_height();
+							el->render_offset_height();
 			} else
 			{
 				base_size = 0;

--- a/src/flex_item.cpp
+++ b/src/flex_item.cpp
@@ -40,7 +40,6 @@ void litehtml::flex_item::init(const litehtml::containing_block_context &self_si
 		main_size = base_size;
 	}
 
-	scaled_flex_shrink_factor = base_size * shrink;
 	frozen = false;
 }
 
@@ -212,6 +211,8 @@ void litehtml::flex_item_row_direction::direction_specific_init(const litehtml::
 		base_size = el->css().get_flex_basis().calc_percent(self_size.render_width) +
 					el->render_offset_width();
 	}
+
+	scaled_flex_shrink_factor = (base_size - el->render_offset_width()) * shrink;
 }
 
 void litehtml::flex_item_row_direction::apply_main_auto_margins()
@@ -391,6 +392,8 @@ void litehtml::flex_item_column_direction::direction_specific_init(const litehtm
 			base_size = (pixel_t) el->css().get_flex_basis().val() + el->render_offset_height();
 		}
 	}
+
+	scaled_flex_shrink_factor = (base_size - el->render_offset_height()) * shrink;
 }
 
 void litehtml::flex_item_column_direction::apply_main_auto_margins()

--- a/src/flex_item.cpp
+++ b/src/flex_item.cpp
@@ -199,8 +199,7 @@ void litehtml::flex_item_row_direction::direction_specific_init(const litehtml::
 	} else
 	{
 		base_size = el->css().get_flex_basis().calc_percent(self_size.render_width) +
-					el->content_offset_width();
-		base_size = std::max(base_size, min_size);
+					el->render_offset_width();
 	}
 }
 
@@ -378,9 +377,8 @@ void litehtml::flex_item_column_direction::direction_specific_init(const litehtm
 			}
 		} else
 		{
-			base_size = (pixel_t) el->css().get_flex_basis().val() + el->content_offset_height();
+			base_size = (pixel_t) el->css().get_flex_basis().val() + el->render_offset_height();
 		}
-		base_size = std::max(base_size, min_size);
 	}
 }
 

--- a/src/flex_item.cpp
+++ b/src/flex_item.cpp
@@ -28,7 +28,18 @@ void litehtml::flex_item::init(const litehtml::containing_block_context &self_si
 	{
 		align = el->css().get_flex_align_self();
 	}
-	main_size = base_size;
+
+	if (base_size < min_size)
+	{
+		main_size = min_size;
+	} else if (!max_size.is_default() && base_size > max_size)
+	{
+		main_size = max_size;
+	} else
+	{
+		main_size = base_size;
+	}
+
 	scaled_flex_shrink_factor = base_size * shrink;
 	frozen = false;
 }

--- a/src/flex_line.cpp
+++ b/src/flex_line.cpp
@@ -21,6 +21,8 @@ void litehtml::flex_line::distribute_free_space_grow(pixel_t container_main_size
 {
 	pixel_t initial_free_space = container_main_size;
 
+	bool all_inflexible = true;
+
 	for (auto& item : items)
 	{
 		// 2. Size inflexible items. Freeze, setting its target main size to its hypothetical main size
@@ -39,6 +41,7 @@ void litehtml::flex_line::distribute_free_space_grow(pixel_t container_main_size
 		} else
 		{
 			initial_free_space -= item->base_size;
+			all_inflexible = false;
 		}
 	}
 
@@ -46,7 +49,9 @@ void litehtml::flex_line::distribute_free_space_grow(pixel_t container_main_size
 
 	// 4.a Check for flexible items. If all the flex items on the line are frozen, free space has been
 	// distributed; exit this loop.
-	
+
+	if (all_inflexible) return;
+
 	while (true)
 	{
 		// 4.b Calculate the remaining free space as for initial free space, above. If the sum of the
@@ -107,6 +112,8 @@ void litehtml::flex_line::distribute_free_space_shrink(pixel_t container_main_si
 {
 	pixel_t initial_free_space = container_main_size;
 
+	bool all_inflexible = true;
+
 	for (auto& item : items)
 	{
 		// 2. Size inflexible items. Freeze, setting its target main size to its hypothetical main size
@@ -125,6 +132,7 @@ void litehtml::flex_line::distribute_free_space_shrink(pixel_t container_main_si
 		} else
 		{
 			initial_free_space -= item->base_size;
+			all_inflexible = false;
 		}
 	}
 
@@ -132,7 +140,9 @@ void litehtml::flex_line::distribute_free_space_shrink(pixel_t container_main_si
 
 	// 4.a Check for flexible items. If all the flex items on the line are frozen, free space has been
 	// distributed; exit this loop.
-	
+
+	if (all_inflexible) return;
+
 	while (true)
 	{
 		// 4.b Calculate the remaining free space as for initial free space, above. If the sum of the

--- a/src/flex_line.cpp
+++ b/src/flex_line.cpp
@@ -7,7 +7,7 @@ void litehtml::flex_line::distribute_free_space(pixel_t container_main_size)
 	// Determine the used flex factor. Sum the outer hypothetical main sizes of all items on the line.
 	// If the sum is less than the flex container’s inner main size, use the flex grow factor for the
 	// rest of this algorithm; otherwise, use the flex shrink factor.
-	pixel_t initial_free_space = container_main_size - base_size;
+	pixel_t initial_free_space = container_main_size - main_size;
 	bool grow;
 	int total_flex_factor;
 	if(initial_free_space < 0)
@@ -21,7 +21,7 @@ void litehtml::flex_line::distribute_free_space(pixel_t container_main_size)
 		{
 			for(auto &item : items)
 			{
-				item->main_size += initial_free_space * item->shrink / 1000;
+				item->main_size = item->base_size + initial_free_space * item->shrink / 1000;
 			}
 			return;
 		}
@@ -36,7 +36,7 @@ void litehtml::flex_line::distribute_free_space(pixel_t container_main_size)
 		{
 			for(auto &item : items)
 			{
-				item->main_size += initial_free_space * item->grow / 1000;
+				item->main_size = item->base_size + initial_free_space * item->grow / 1000;
 			}
 			return;
 		}
@@ -195,16 +195,16 @@ void litehtml::flex_line::init(pixel_t container_main_size, bool fit_container, 
 							   const litehtml::containing_block_context &self_size,
 							   litehtml::formatting_context *fmt_ctx)
 {
-	cross_size = 0;
-	main_size = 0;
-	first_baseline.set(0, baseline::baseline_type_none);
-	last_baseline.set(0, baseline::baseline_type_none);
-
 	if(!fit_container)
 	{
 		distribute_free_space(container_main_size);
 	}
 
+	cross_size = 0;
+	main_size = 0;
+	first_baseline.set(0, baseline::baseline_type_none);
+	last_baseline.set(0, baseline::baseline_type_none);
+	
 	if(is_row_direction)
 	{
 		def_value<pixel_t> first_baseline_top = 0;

--- a/src/flex_line.cpp
+++ b/src/flex_line.cpp
@@ -238,20 +238,17 @@ bool litehtml::flex_line::fix_min_max_violations()
 		? flex_clamp_state_min_violation
 		: flex_clamp_state_max_violation;
 
-	if (total_violation > 0)
+	for (auto& item : items)
 	{
-		for (auto& item : items)
+		if (!item->frozen)
 		{
-			if (!item->frozen)
+			if (item->clamp_state == state_to_freeze)
 			{
-				if (item->clamp_state == state_to_freeze)
-				{
-					item->frozen = true;
-				} else
-				{
-					all_frozen = false;
-					item->clamp_state = flex_clamp_state_unclamped;
-				}
+				item->frozen = true;
+			} else
+			{
+				all_frozen = false;
+				item->clamp_state = flex_clamp_state_unclamped;
 			}
 		}
 	}

--- a/src/flex_line.cpp
+++ b/src/flex_line.cpp
@@ -48,6 +48,7 @@ void litehtml::flex_line::distribute_free_space(pixel_t container_main_size)
 		while (processed)
 		{
 			pixel_t sum_scaled_flex_shrink_factor = 0;
+			int sum_flex_grow_factor = 0;
 			pixel_t remaining_free_space = container_main_size;
 			int total_not_frozen = 0;
 			for (auto &item: items)
@@ -55,6 +56,7 @@ void litehtml::flex_line::distribute_free_space(pixel_t container_main_size)
 				if (!item->frozen)
 				{
 					sum_scaled_flex_shrink_factor += item->scaled_flex_shrink_factor;
+					sum_flex_grow_factor += item->grow;
 					remaining_free_space -= item->base_size;
 					total_not_frozen++;
 				} else
@@ -115,7 +117,7 @@ void litehtml::flex_line::distribute_free_space(pixel_t container_main_size)
 							//    factors of all unfrozen items on the line. Set the item’s target main size to
 							//    its flex base size plus a fraction of the remaining free space proportional
 							//    to the ratio.
-							item->main_size = item->base_size + remaining_free_space * (pixel_t) item->grow / (pixel_t) total_flex_factor;
+							item->main_size = item->base_size + remaining_free_space * (pixel_t) item->grow / (pixel_t) sum_flex_grow_factor;
 
 							// d. Fix min/max violations. Clamp each non-frozen item’s target main size by its used
 							// min and max main sizes and floor its content-box size at zero. If the item’s target

--- a/src/flex_line.cpp
+++ b/src/flex_line.cpp
@@ -139,25 +139,6 @@ void litehtml::flex_line::distribute_free_space(pixel_t container_main_size)
 				if (total_clamped == 0) processed = false;
 			}
 		}
-		// Distribute remaining after algorithm space
-		pixel_t sum_main_size = 0;
-		for(auto &item : items)
-		{
-			sum_main_size += item->main_size;
-		}
-
-		pixel_t free_space = container_main_size - sum_main_size;
-
-		pixel_t ditribute_step = 1;
-		if(free_space > 0)
-		{
-			for(auto &item : items)
-			{
-				if(free_space < ditribute_step) break;
-				item->main_size += ditribute_step;
-				free_space -= ditribute_step;
-			}
-		}
 	}
 }
 

--- a/src/render_block.cpp
+++ b/src/render_block.cpp
@@ -279,10 +279,7 @@ litehtml::pixel_t litehtml::render_item_block::_render(pixel_t x, pixel_t y, con
 		{
 			m_pos.height = self_size.height;
 		}
-		if (src_el()->css().get_box_sizing() == box_sizing_border_box)
-		{
-			m_pos.height -= box_sizing_height();
-		}
+		m_pos.height -= box_sizing_height();
 	} else if (src_el()->is_block_formatting_context())
 	{
 		// add the floats' height to the block height

--- a/src/render_flex.cpp
+++ b/src/render_flex.cpp
@@ -35,11 +35,7 @@ litehtml::pixel_t litehtml::render_item_flex::_render_content(pixel_t x, pixel_t
 	{
 		if(self_size.height.type != containing_block_context::cbc_value_type_auto)
 		{
-			container_main_size = self_size.height;
-			if (css().get_box_sizing() == box_sizing_border_box)
-			{
-				container_main_size -= box_sizing_height();
-			}
+			container_main_size = self_size.height - box_sizing_height();
 		} else
 		{
 			// Direction columns, height is auto - always in single line
@@ -100,11 +96,7 @@ litehtml::pixel_t litehtml::render_item_flex::_render_content(pixel_t x, pixel_t
 	{
 		if (self_size.height.type != containing_block_context::cbc_value_type_auto)
 		{
-			pixel_t height = self_size.height;
-			if (src_el()->css().get_box_sizing() == box_sizing_border_box)
-			{
-				height -= box_sizing_height();
-			}
+			pixel_t height = self_size.height - box_sizing_height();
 			free_cross_size = height - sum_cross_size;
 		}
 	} else

--- a/src/render_flex.cpp
+++ b/src/render_flex.cpp
@@ -301,12 +301,13 @@ std::list<litehtml::flex_line> litehtml::render_item_flex::get_lines(const liteh
 	// Add flex items to lines
 	for(auto& item : items)
 	{
-		if(!line.items.empty() && !single_line && line.base_size + item->base_size > container_main_size)
+		if(!line.items.empty() && !single_line && line.main_size + item->main_size > container_main_size)
 		{
 			lines.emplace_back(line);
 			line = flex_line(reverse_main, reverse_cross);
 		}
 		line.base_size += item->base_size;
+		line.main_size += item->main_size;
 		line.total_grow += item->grow;
 		line.total_shrink += item->shrink;
 		if(!item->auto_margin_main_start.is_default()) line.num_auto_margin_main_start++;

--- a/src/render_flex.cpp
+++ b/src/render_flex.cpp
@@ -300,8 +300,6 @@ std::list<litehtml::flex_line> litehtml::render_item_flex::get_lines(const liteh
 		}
 		line.base_size += item->base_size;
 		line.main_size += item->main_size;
-		line.total_grow += item->grow;
-		line.total_shrink += item->shrink;
 		if(!item->auto_margin_main_start.is_default()) line.num_auto_margin_main_start++;
 		if(!item->auto_margin_main_end.is_default()) line.num_auto_margin_main_end++;
 		line.items.push_back(item);


### PR DESCRIPTION
This PR fixes the issues in #419, by changing the flex layout implementation to more closely match the algorithm outlined in the [spec](https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths).  

Apart from the actual space distribution algorithm, I've also had to change how some of its per-flex-item inputs are calculated. `flex_item::main_size` is now set to the item's hypothetical main size before space distribution. `scaled_flex_shrink_factor` is now correctly calculated from the inner base size, instead of the outer one.

There is a new `flex_item::clamp_state` field, which is used when fixing min/max violations. It could also be used to tell why an item was sized in a particular way, kinda like how the developer tools in browsers show clamping. Maybe the dump function could be extended in the future to also print things about the state of render items.

I've also noticed, that `box-sizing` was not correctly handled for min/max/base sizes, which was causing some test failures after changing the algorithm. That's also fixed now.

There is still one `box-sizing` related problem I know of, that I haven't fixed. When the flex container itself uses `border-box`, percentage min/max/base sizes are calculated relative to the container's border box size, but they should be relative to the container's inner size. But this is not really related to the free space distribution algorithm, so I would say it's out of scope for this PR.

With these changes, there are a total of 22 failing tests. Most of these have actually been improved, the "failed" outputs match how other browsers work, the originals were slightly off.

There is 1 exception, `flex/table-as-item-stretch-cross-size-3.htm` is now failing. This case has a column direction flex container, with a table in it, with `90px` body height, and a `10px` high caption. This results in a min size of `100px` and a base size of `90px`. The hypothetical main size is `100px`. This also ends up being the used main size, because the flex container has infinite inner main size, but the same thing would happen if it didn't, as the table is inflexible. The table is then rendered with a size of `100px`, which is supposed to be its outer size, but it ends up being used as its table box size. So it's oversized by the size of the caption. The caption size should be subtracted from the main size before rendering, like the padding/border/margin, but I don't really know how to do that currently.

The case originally worked, because the min size wasn't taken into account, so it ended up with a used main size of `90px`.

This seems like a pretty niche thing though, so I would suggest also considering this out of scope now, and opening issues for the outstanding problems.

Closes #419