### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The litebrowser source codes are available on GitHub:
 ## License
 
 **litehtml** is distributed under [New BSD License](https://opensource.org/licenses/BSD-3-Clause).
-The **gumbo-parser** is disributed under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+The **gumbo-parser** is distributed under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 ## Links
 

--- a/containers/haiku/container_haiku.cpp
+++ b/containers/haiku/container_haiku.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright 2019-2020 Haiku Inc.
  * All rights reserved. Distributed under the terms of the BSD 3-clause license.
- * Constributors
+ * Contributors
  * 2019-2020	Adam Fowler <adamfowleruk@gmail.com>
  */
 #include "container_haiku.h"

--- a/containers/haiku/container_haiku.h
+++ b/containers/haiku/container_haiku.h
@@ -1,7 +1,7 @@
 /*
  * Copyright 2019-2020 Haiku Inc.
  * All rights reserved. Distributed under the terms of the BSD 3-clause license.
- * Constributors
+ * Contributors
  * 2019-2020	Adam Fowler <adamfowleruk@gmail.com>
  */
 #ifndef LITEHTMLVIEW_H

--- a/containers/test/canvas_ity.hpp
+++ b/containers/test/canvas_ity.hpp
@@ -260,7 +260,7 @@ public:
 
     /// @brief  Add an arbitrary transform to the current transform.
     ///
-    /// This takes six values for the upper two rows of a homogenous 3x3
+    /// This takes six values for the upper two rows of a homogeneous 3x3
     /// matrix (i.e., {{a, c, e}, {b, d, f}, {0.0, 0.0, 1.0}}) describing an
     /// arbitrary affine transform and appends it to the current transform.
     /// The values can represent any affine transform such as scaling,
@@ -285,7 +285,7 @@ public:
 
     /// @brief  Replace the current transform.
     ///
-    /// This takes six values for the upper two rows of a homogenous 3x3
+    /// This takes six values for the upper two rows of a homogeneous 3x3
     /// matrix (i.e., {{a, c, e}, {b, d, f}, {0.0, 0.0, 1.0}}) describing
     /// an arbitrary affine transform and replaces the current transform
     /// with it.  The values can represent any affine transform such as

--- a/containers/test/lodepng.cpp
+++ b/containers/test/lodepng.cpp
@@ -1371,7 +1371,7 @@ static unsigned inflateNoCompression(ucvector* out, LodePNGBitReader* reader,
   /*read the literal data: LEN bytes are now stored in the out buffer*/
   if(bytepos + LEN > size) return 23; /*error: reading outside of in buffer*/
 
-  /*out->data can be NULL (when LEN is zero), and arithmetics on NULL ptr is undefined*/
+  /*out->data can be NULL (when LEN is zero), and arithmetic on NULL ptr is undefined*/
   if (LEN) {
     lodepng_memcpy(out->data + out->size - LEN, reader->data + bytepos, LEN);
     bytepos += LEN;
@@ -6060,7 +6060,7 @@ unsigned lodepng_encode(unsigned char** out, size_t* outsize,
     if(state->encoder.force_palette) {
       if(info.color.colortype != LCT_GREY && info.color.colortype != LCT_GREY_ALPHA &&
          (auto_color.colortype == LCT_GREY || auto_color.colortype == LCT_GREY_ALPHA)) {
-        /*user speficially forced a PLTE palette, so cannot convert to grayscale types because
+        /*user specifically forced a PLTE palette, so cannot convert to grayscale types because
         the PNG specification only allows writing a suggested palette in PLTE for truecolor types*/
         allow_convert = 0;
       }

--- a/containers/test/lodepng.h
+++ b/containers/test/lodepng.h
@@ -832,7 +832,7 @@ typedef struct LodePNGEncoderSettings {
   const unsigned char* predefined_filters;
 
   /*force creating a PLTE chunk if colortype is 2 or 6 (= a suggested palette).
-  If colortype is 3, PLTE is always created. If color type is explicitely set
+  If colortype is 3, PLTE is always created. If color type is explicitly set
   to a grayscale type (1 or 4), this is not done and is ignored. If enabling this,
   a palette must be present in the info_png.
   NOTE: enabling this may worsen compression if auto_convert is used to choose
@@ -996,7 +996,7 @@ unsigned lodepng_chunk_append(unsigned char** out, size_t* outsize, const unsign
 Appends new chunk to out. The chunk to append is given by giving its length, type
 and data separately. The type is a 4-letter string.
 The out variable and outsize are updated to reflect the new reallocated buffer.
-Returne error code (0 if it went ok)
+Return error code (0 if it went ok)
 */
 unsigned lodepng_chunk_create(unsigned char** out, size_t* outsize, unsigned length,
                               const char* type, const unsigned char* data);
@@ -1871,7 +1871,7 @@ state.decoder.remember_unknown_chunks: whether to read in unknown chunks
 state.info_raw.colortype: desired color type for decoded image
 state.info_raw.bitdepth: desired bit depth for decoded image
 state.info_raw....: more color settings, see struct LodePNGColorMode
-state.info_png....: no settings for decoder but ouput, see struct LodePNGInfo
+state.info_png....: no settings for decoder but output, see struct LodePNGInfo
 
 For encoding:
 

--- a/src/css_parser.cpp
+++ b/src/css_parser.cpp
@@ -141,7 +141,7 @@ css_token_vector normalize(string input, int options, keep_whitespace_fn keep_wh
 }
 
 // https://www.w3.org/TR/css-syntax-3/#parse-stylesheet
-// I don't create a stylesheet because its only perpose is to pass a list of rules to
+// I don't create a stylesheet because its only purpose is to pass a list of rules to
 // parse_css_stylesheet. I just return the list of rules directly instead.
 raw_rule::vector css_parser::parse_stylesheet(const string& input, bool top_level)
 {

--- a/src/encodings.cpp
+++ b/src/encodings.cpp
@@ -2031,7 +2031,7 @@ void encoding_sniffing_algorithm(estring& str)
 	if (str.encoding == encoding::null)
 	{
 		str.encoding = encoding::utf_8;
-		str.confidence = confidence::tentative; // tentative means it will be overriden by <meta> encoding if present
+		str.confidence = confidence::tentative; // tentative means it will be overridden by <meta> encoding if present
 	}
 	// otherwise use str.encoding (tentative)
 }

--- a/src/gumbo/tokenizer.c
+++ b/src/gumbo/tokenizer.c
@@ -83,7 +83,7 @@ typedef struct GumboInternalTagState {
   const char* _original_text;
 
   // The current tag enum, computed once the tag name state has finished so that
-  // the buffer can be re-used for building up attributes.
+  // the buffer can be reused for building up attributes.
   GumboTag _tag;
 
   // The starting location of the text in the buffer.
@@ -409,7 +409,7 @@ static void reset_token_start_point(GumboTokenizerState* tokenizer) {
 
 // Sets the tag buffer original text and start point to the current iterator
 // position.  This is necessary because attribute names & values may have
-// whitespace preceeding them, and so we can't assume that the actual token
+// whitespace preceding them, and so we can't assume that the actual token
 // starting point was the end of the last tag buffer usage.
 static void reset_tag_buffer_start_point(GumboParser* parser) {
   GumboTokenizerState* tokenizer = parser->_tokenizer_state;

--- a/src/line_box.cpp
+++ b/src/line_box.cpp
@@ -435,7 +435,7 @@ std::list< std::unique_ptr<litehtml::line_box_item> > litehtml::line_box::finish
 			{
 			case va_bottom:
 			case va_top:
-				// Align by base line 0 all inline boxes with top and bottom vertical aling
+				// Align by base line 0 all inline boxes with top and bottom vertical align
 				bl = 0;
 				is_top_bottom_box = true;
 				break;
@@ -584,7 +584,7 @@ std::list< std::unique_ptr<litehtml::line_box_item> > litehtml::line_box::finish
 		}
 	} else
 	{
-		// Add inline boxes dimentions
+		// Add inline boxes dimensions
 		line_max_height.top = std::min(line_max_height.top, inline_boxes_dims.top);
 		line_max_height.bottom = std::max(line_max_height.bottom, inline_boxes_dims.bottom);
 

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -1663,7 +1663,7 @@ void style::subst_vars(const html_tag* el)
 			auto& value = prop.second.get<css_token_vector>();
 			subst_vars_(prop.first, value, el);
 			// re-adding the same property
-			// if it is a custom property it will be readded as a css_token_vector
+			// if it is a custom property it will be re-added as a css_token_vector
 			// if it is a standard css property it will be parsed and properly added as typed property
 			add_property(prop.first, value, "", prop.second.m_important, el->get_document()->container());
 		}

--- a/support/README.md
+++ b/support/README.md
@@ -251,7 +251,7 @@ Returns ```true``` if something is downloading.
 
 ### litebrowser::draw_buffer
 
-A helper class to perform the draw operations into the cairo surface. The application draws everything to the buffer, then buffer are drawn on widged or window.
+A helper class to perform the draw operations into the cairo surface. The application draws everything to the buffer, then buffer are drawn on widget or window.
 
 Some notes about scaling support:
 * All functions accept scale independent coordinates and sizes. So don't apply scale to the coordinates and sizes.


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=inout,paeth,te`
```
./README.md:33: disributed ==> distributed
./support/README.md:254: widged ==> widget
./containers/test/canvas_ity.hpp:263: homogenous ==> homogeneous
./containers/test/canvas_ity.hpp:288: homogenous ==> homogeneous
./containers/test/lodepng.cpp:1374: arithmetics ==> arithmetic
./containers/test/lodepng.cpp:6063: speficially ==> specifically
./containers/test/lodepng.h:835: explicitely ==> explicitly
./containers/test/lodepng.h:999: Returne ==> Returned, Return
./containers/test/lodepng.h:1874: ouput ==> output
./containers/haiku/container_haiku.cpp:4: Constributors ==> Contributors
./containers/haiku/container_haiku.h:4: Constributors ==> Contributors
./src/css_parser.cpp:144: perpose ==> purpose, propose
./src/encodings.cpp:2034: overriden ==> overridden
./src/line_box.cpp:438: aling ==> align, along, a line, ailing, sling
./src/line_box.cpp:587: dimentions ==> dimensions
./src/style.cpp:1666: readded ==> re-added, read
./src/gumbo/tokenizer.c:86: re-used ==> reused
./src/gumbo/tokenizer.c:412: preceeding ==> preceding, proceeding
```
% `codespell --ignore-words-list=inout,paeth,te --write-changes` 