### PR TITLE
adding document_container::draw_finished(...)

### DIFF
--- a/include/litehtml/document_container.h
+++ b/include/litehtml/document_container.h
@@ -71,6 +71,8 @@ namespace litehtml
 		virtual litehtml::string	resolve_color(const litehtml::string& /*color*/) const { return litehtml::string(); }
 		virtual void				split_text(const char* text, const std::function<void(const char*)>& on_word, const std::function<void(const char*)>& on_space);
 
+		// Optional, used for cache draw command, and in this func to draw
+		virtual void                draw_finished(litehtml::uint_ptr hdc) {};
 	protected:
 		virtual ~document_container() = default;
 	};

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -534,6 +534,7 @@ void document::draw( uint_ptr hdc, pixel_t x, pixel_t y, const position* clip )
 	{
 		m_root->draw(hdc, x, y, clip, m_root_render);
 		m_root_render->draw_stacking_context(hdc, x, y, clip, true);
+		m_container->draw_finished(hdc);
 	}
 }
 


### PR DESCRIPTION
adding draw_finished used for cache `draw_*** `command, used for improve performance , it's optional , based on container, below is my test` cache draw_text(...)` command result( i merge same line of draw_text that have same font and same color to reduce call system draw method), but for now i'm not finished, it's a test, but my code may not easy to read, 

[BEFORE]
```
11:32:51: [1]    get_media_features     : 0.000 006 100 s,      1 Hz

11:32:51: [1]    create_font            : 0.004 845 700 s,      6 Hz

11:32:51: [1]    text_width             : 0.049 671 600 s,    773 Hz

11:32:51: [1]    delete_font            : 0.000 012 800 s,     20 Hz

11:32:51: [*][createFromString]         : 0.096 154 300 s,      1 Hz

11:32:51: [1]    get_viewport           : 0.000 001 500 s,      1 Hz

11:32:51: [1]    text_width             : 0.154 326 300 s,   2446 Hz

11:32:51: [*][render]                   : 0.243 452 900 s,      1 Hz

11:32:51: [1]    draw_solid_fill        : 0.000 635 800 s,      1 Hz

11:32:51: [1]    draw_list_marker       : 0.000 120 800 s,      5 Hz

11:32:51: [1]    draw_text              : 0.031 888 900 s,    315 Hz

11:32:51: [*][draw]                     : 0.034 354 700 s,      1 Hz
```

[AFTER]
```
12:18:29: [1]    get_media_features     : 0.000 006 700 s,      1 Hz

12:18:29: [1]    create_font            : 0.003 521 800 s,      6 Hz

12:18:29: [1]    text_width             : 0.035 528 600 s,    773 Hz

12:18:29: [1]    delete_font            : 0.000 010 100 s,     15 Hz

12:18:29: [*][createFromString]         : 0.070 072 500 s,      1 Hz

12:18:29: [1]    get_viewport           : 0.000 001 500 s,      1 Hz

12:18:29: [1]    text_width             : 0.113 403 800 s,   2446 Hz

12:18:29: [*][render]                   : 0.173 361 900 s,      1 Hz

12:18:29: [1]    draw_solid_fill        : 0.002 684 100 s,      1 Hz

12:18:29: [1]    draw_list_marker       : 0.000 114 600 s,      5 Hz

12:18:29: [1]    draw_text              : 0.000 413 300 s,    640 Hz

12:18:29: [1]    draw_finished          : 0.018 099 100 s,      1 Hz

12:18:29: [*][draw]                     : 0.022 607 700 s,      1 Hz
```

and below is i test code
```cpp
class DrawCache
{
public:
    DrawCache() {};
    ~DrawCache() {};
    
    struct Text
    {
        litehtml::uint_ptr hFont;
        std::string text;
        litehtml::web_color color;
        const litehtml::position pos;
    };
    void add(litehtml::uint_ptr hFont, 
        const char* text, 
        litehtml::web_color color, 
        const litehtml::position& pos)
    {
        if(text)
        {
            if(m_cache.empty())
            {
                m_cache.push_back(Text{ hFont, std::string(text), color, pos });
            }
         
            else
            {
                std::string t(text);
                auto back = m_cache.back();
                // merge
                if(back.hFont == hFont &&
                    back.color == color &&
                    back.pos.y == pos.y)
                
                {
                    m_cache.pop_back();
                    back.text += t;
                    m_cache.push_back(back);
                }
                else
                {
                    m_cache.push_back(Text{ hFont, std::string(text), color, pos });
                }
            }
        }
    }

    std::vector<Text> get_cache() { return m_cache; }
    void clear() { m_cache.clear(); }
private:

    std::vector<Text> m_cache;
};
```
```cpp
void wxContainer::draw_text(litehtml::uint_ptr hdc, const char* text,
    litehtml::uint_ptr hFont, litehtml::web_color color, const litehtml::position& pos)
{
   //    DrawCache m_cache;
    std::unique_ptr<Timer> timer = std::make_unique<Timer>("draw_text", 1);
    m_cache.add(hFont, text, color, pos);
}
```
```cpp
void wxContainer::draw_finished(litehtml::uint_ptr hdc)
{
    std::unique_ptr<Timer> timer = std::make_unique<Timer>("draw_finished", 1);
    wxDC* dc = (wxDC*)hdc;
    if(dc)
    {
        for (auto& cache: m_cache.get_cache())
        {
            wxFont* font = (wxFont*)cache.hFont;
            if(font)
            {
                dc->SetFont(*font);
                dc->SetTextForeground(wxColour(cache.color.red, cache.color.green, cache.color.blue));
                dc->DrawText(wxString::FromUTF8(cache.text), cache.pos.x, cache.pos.y);
            }

        }
    }
    m_cache.clear();
    timer.reset();
}
```
