### PR TITLE
Do not justify the last line of a paragraph

### DIFF
--- a/include/litehtml/line_box.h
+++ b/include/litehtml/line_box.h
@@ -170,7 +170,7 @@ namespace litehtml
         pixel_t				top_margin() const;
         pixel_t				bottom_margin() const;
         void				y_shift(pixel_t shift);
-		std::list< std::unique_ptr<line_box_item> >	finish(bool last_box, const containing_block_context &containing_block_size);
+		std::list< std::unique_ptr<line_box_item> >	finish(bool last_box, const containing_block_context &containing_block_size, bool is_last_line = false);
 		std::list< std::unique_ptr<line_box_item> > new_width(pixel_t left, pixel_t right);
 		std::shared_ptr<render_item> 		get_last_text_part() const;
 		std::shared_ptr<render_item> 		get_first_text_part() const;

--- a/include/litehtml/render_inline_context.h
+++ b/include/litehtml/render_inline_context.h
@@ -37,6 +37,9 @@ namespace litehtml
 
 		std::list<std::unique_ptr<line_box_item> > finish_last_box(bool end_of_render, const containing_block_context &self_size);
 		void place_inline(std::unique_ptr<line_box_item> item, const containing_block_context &self_size, formatting_context* fmt_ctx);
+
+        bool end_of_render(const shared_ptr<element> &el);
+
 		pixel_t new_box(const std::unique_ptr<line_box_item>& el, line_context& line_ctx, const containing_block_context &self_size, formatting_context* fmt_ctx);
 		void apply_vertical_align() override;
 	public:

--- a/include/litehtml/render_inline_context.h
+++ b/include/litehtml/render_inline_context.h
@@ -35,10 +35,10 @@ namespace litehtml
 		void fix_line_width(element_float flt,
 							const containing_block_context &self_size, formatting_context* fmt_ctx) override;
 
-		std::list<std::unique_ptr<line_box_item> > finish_last_box(bool end_of_render, const containing_block_context &self_size);
+		std::list<std::unique_ptr<line_box_item> > finish_last_box(bool end_of_render, const containing_block_context &self_size, bool is_last_line = false);
 		void place_inline(std::unique_ptr<line_box_item> item, const containing_block_context &self_size, formatting_context* fmt_ctx);
 
-        bool end_of_render(const shared_ptr<element> &el);
+        bool end_of_line(const shared_ptr<element> &el);
 
 		pixel_t new_box(const std::unique_ptr<line_box_item>& el, line_context& line_ctx, const containing_block_context &self_size, formatting_context* fmt_ctx);
 		void apply_vertical_align() override;

--- a/src/line_box.cpp
+++ b/src/line_box.cpp
@@ -318,9 +318,9 @@ std::list< std::unique_ptr<litehtml::line_box_item> > litehtml::line_box::finish
             {
 				shift_x = 0;
 				spacing_x = (m_right - m_left) - m_width;
-				// don't justify for small lines
-                if (spacing_x > m_width / 4)
-					spacing_x = 0;
+            	// don't justify the last line or small lines
+            	if (last_box || spacing_x > m_width / 2)
+            		spacing_x = 0;
             }
             break;
         default:

--- a/src/line_box.cpp
+++ b/src/line_box.cpp
@@ -215,7 +215,7 @@ litehtml::pixel_t litehtml::line_box::calc_va_baseline(const va_context& current
 	}
 }
 
-std::list< std::unique_ptr<litehtml::line_box_item> > litehtml::line_box::finish(bool last_box, const containing_block_context &containing_block_size)
+std::list< std::unique_ptr<litehtml::line_box_item> > litehtml::line_box::finish(bool last_box, const containing_block_context &containing_block_size, bool is_last_line)
 {
 	std::list< std::unique_ptr<line_box_item> > ret_items;
 
@@ -319,7 +319,7 @@ std::list< std::unique_ptr<litehtml::line_box_item> > litehtml::line_box::finish
 				shift_x = 0;
 				spacing_x = (m_right - m_left) - m_width;
             	// don't justify the last line or small lines
-            	if (last_box || spacing_x > m_width / 2)
+            	if (is_last_line || spacing_x > m_width / 2)
             		spacing_x = 0;
             }
             break;

--- a/src/render_inline_context.cpp
+++ b/src/render_inline_context.cpp
@@ -182,9 +182,10 @@ std::list<std::unique_ptr<litehtml::line_box_item> > litehtml::render_item_inlin
     return ret;
 }
 
+
 litehtml::pixel_t litehtml::render_item_inline_context::new_box(const std::unique_ptr<line_box_item>& el, line_context& line_ctx, const containing_block_context &self_size, formatting_context* fmt_ctx)
 {
-	auto items = finish_last_box(false, self_size);
+    auto items = finish_last_box(end_of_render(el->get_el()->src_el()), self_size);
 	pixel_t line_top = 0;
 	if(!m_line_boxes.empty())
 	{
@@ -345,6 +346,19 @@ void litehtml::render_item_inline_context::place_inline(std::unique_ptr<line_box
     }
 
 	m_line_boxes.back()->add_item(std::move(item));
+}
+
+bool litehtml::render_item_inline_context::end_of_render(const shared_ptr<element> &el) {
+    if (!m_line_boxes.empty() && !m_line_boxes.back()->items().empty()) {
+        if (m_line_boxes.back()->items().back()->get_el()->src_el()->is_break()) {
+            return true;
+        }
+    }
+    auto display_style = el->css().get_display();
+    if (display_style == display_inline_block || display_style == display_block) {
+        return true;
+    }
+    return false;
 }
 
 void litehtml::render_item_inline_context::apply_vertical_align()

--- a/src/render_inline_context.cpp
+++ b/src/render_inline_context.cpp
@@ -68,7 +68,7 @@ litehtml::pixel_t litehtml::render_item_inline_context::_render_content(pixel_t 
 			}
         });
 
-    finish_last_box(true, self_size);
+    finish_last_box(true, self_size, true);
 
     if (!m_line_boxes.empty())
     {
@@ -162,13 +162,13 @@ void litehtml::render_item_inline_context::fix_line_width(element_float flt,
     }
 }
 
-std::list<std::unique_ptr<litehtml::line_box_item> > litehtml::render_item_inline_context::finish_last_box(bool end_of_render, const containing_block_context &self_size)
+std::list<std::unique_ptr<litehtml::line_box_item> > litehtml::render_item_inline_context::finish_last_box(bool end_of_render, const containing_block_context &self_size, bool is_last_line)
 {
 	std::list<std::unique_ptr<line_box_item> > ret;
 
     if(!m_line_boxes.empty())
     {
-		ret = m_line_boxes.back()->finish(end_of_render, self_size);
+		ret = m_line_boxes.back()->finish(end_of_render, self_size, is_last_line);
 
         if(m_line_boxes.back()->is_empty() && end_of_render)
         {
@@ -185,7 +185,7 @@ std::list<std::unique_ptr<litehtml::line_box_item> > litehtml::render_item_inlin
 
 litehtml::pixel_t litehtml::render_item_inline_context::new_box(const std::unique_ptr<line_box_item>& el, line_context& line_ctx, const containing_block_context &self_size, formatting_context* fmt_ctx)
 {
-    auto items = finish_last_box(end_of_render(el->get_el()->src_el()), self_size);
+    auto items = finish_last_box(false, self_size, end_of_line(el->get_el()->src_el()));
 	pixel_t line_top = 0;
 	if(!m_line_boxes.empty())
 	{
@@ -348,7 +348,7 @@ void litehtml::render_item_inline_context::place_inline(std::unique_ptr<line_box
 	m_line_boxes.back()->add_item(std::move(item));
 }
 
-bool litehtml::render_item_inline_context::end_of_render(const shared_ptr<element> &el) {
+bool litehtml::render_item_inline_context::end_of_line(const shared_ptr<element> &el) {
     if (!m_line_boxes.empty() && !m_line_boxes.back()->items().empty()) {
         if (m_line_boxes.back()->items().back()->get_el()->src_el()->is_break()) {
             return true;


### PR DESCRIPTION
When justifying a paragraph the last line should not be justified, even if it is wide. This is also the case if there is only one line in the paragraph. It is more prominent if you have smaller boxes, e.g. table cells that are justified and only has one line.