### PR TITLE
adding two overload for  litehtml::createFromString(..)

### DIFF
--- a/doc/document_createFromString.md
+++ b/doc/document_createFromString.md
@@ -1,3 +1,45 @@
+## UTF-8 Encoding
+
+```cpp
+static document::ptr  document::createFromString(
+    const string&       str,
+    document_container*  container,
+    const string&        master_styles = litehtml::master_css,
+    const string&        user_styles = "");
+```
+
+```cpp
+static document::ptr  document::createFromString(
+    const char*       str,
+    document_container*  container,
+    const string&        master_styles = litehtml::master_css,
+    const string&        user_styles = "");
+```
+
+if you ensure it's conding is `utf-8`, you can simply:
+
+```cpp
+std::string html = "<html>...</html>"
+auto doc = litehtml::createFromString(html, container);
+```
+
+or you can alse just using like this:
+
+```cpp
+std::string html = "<html>this is test doc</html>"
+auto doc = litehtml::createFromString("<html>...</html>", container);
+```
+
+### Parameter
+
+- **str** is input `HTML` string;
+- **container** is platform specific, you could use already existed ( for example `win32_container` `cario_container` and so on), or just according to `litehtml::document_container()` to write youself's container 
+-  **master_styles** is all element's default css style
+- **user_styles** is that you can self define, and `user_styles` > `master_styles`
+
+
+## Advanced Encoding
+
 ```cpp
 static document::ptr  document::createFromString(
 	const estring&       str,

--- a/doc/document_createFromString.md
+++ b/doc/document_createFromString.md
@@ -16,26 +16,35 @@ static document::ptr  document::createFromString(
     const string&        user_styles = "");
 ```
 
-if you ensure it's conding is `utf-8`, you can simply:
+if it's conding is `utf-8`, you can simply:
 
 ```cpp
-std::string html = "<html>...</html>"
+std::string html = "<html>...</html>";
 auto doc = litehtml::createFromString(html, container);
 ```
 
-or you can alse just using like this:
+or just:
 
 ```cpp
-std::string html = "<html>this is test doc</html>"
 auto doc = litehtml::createFromString("<html>...</html>", container);
+```
+
+if you want adding custom style:
+
+```cpp
+std::string css = "<style>....</style>";
+auto doc = litehtml::createFromString("<html>...</html>", container, litehtml::master_css, css);
 ```
 
 ### Parameter
 
 - **str** is input `HTML` string;
-- **container** is platform specific, you could use already existed ( for example `win32_container` `cario_container` and so on), or just according to `litehtml::document_container()` to write youself's container 
+
+- **container** is platform specific, you could use already existed ( for example `win32_container` `cario_container` and so on), or just according to `litehtml::document_container()` to write you own's container 
+
 -  **master_styles** is all element's default css style
-- **user_styles** is that you can self define, and `user_styles` > `master_styles`
+
+- **user_styles** is user custom css style, it's highest priority, and `user_styles` > HTML content's CSS( style sheets **linked in document** and **seperate css file**  ) > `master_styles`
 
 
 ## Advanced Encoding

--- a/doc/document_createFromString.md
+++ b/doc/document_createFromString.md
@@ -16,7 +16,7 @@ static document::ptr  document::createFromString(
     const string&        user_styles = "");
 ```
 
-if it's conding is `utf-8`, you can simply:
+if it's enconding is `utf-8`, you can simply:
 
 ```cpp
 std::string html = "<html>...</html>";
@@ -38,13 +38,13 @@ auto doc = litehtml::createFromString("<html>...</html>", container, litehtml::m
 
 ### Parameter
 
-- **str** is input `HTML` string;
+- `str` is input **HTML** string;
 
-- **container** is platform specific, you could use already existed ( for example `win32_container` `cario_container` and so on), or just according to `litehtml::document_container()` to write you own's container 
+- `container` is platform specific, you could use already existed ( for example **win32_container** **cario_container** and so on), or just according to **litehtml::document_container()** to write you own's container 
 
--  **master_styles** is all element's default css style
+-  `master_styles` is all element's **default** css style
 
-- **user_styles** is user custom css style, it's highest priority, and `user_styles` > HTML content's CSS( style sheets **linked in document** and **seperate css file**  ) > `master_styles`
+- `user_styles` is user custom css style, it's **highest** priority, and `user_styles` > HTML content's CSS( style sheets **linked in document** and **seperate css file**  ) > `master_styles`
 
 
 ## Advanced Encoding

--- a/include/litehtml/document.h
+++ b/include/litehtml/document.h
@@ -115,6 +115,18 @@ namespace litehtml
 			const string&        master_styles = litehtml::master_css,
 			const string&        user_styles = "");
 
+		static document::ptr  createFromString(
+			const char* str,
+			document_container* container,
+			const string& master_styles = litehtml::master_css,
+			const string& user_styles = "");
+
+		static document::ptr  createFromString(
+			const string& str,
+			document_container* container,
+			const string& master_styles = litehtml::master_css,
+			const string& user_styles = "");
+
 	private:
 		uint_ptr	add_font(const font_description& descr, font_metrics* fm);
 

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -149,6 +149,17 @@ document::ptr document::createFromString(
 	return doc;
 }
 
+document::ptr document::createFromString(const char* str, document_container* container, const string& master_styles, const string& user_styles)
+{
+	if (!str) { return nullptr; }
+	return createFromString({str, encoding::utf_8}, container, master_styles, user_styles);
+}
+
+document::ptr document::createFromString(const string& str, document_container* container, const string& master_styles, const string& user_styles)
+{
+	return createFromString(str.c_str(), container, master_styles, user_styles);
+}
+
 // https://html.spec.whatwg.org/multipage/parsing.html#change-the-encoding
 encoding adjust_meta_encoding(encoding meta_encoding, encoding current_encoding)
 {


### PR DESCRIPTION
 it can simplify the usage , if its encoding is `utf-8`

use two overload just for performance, and it can compatible with litehtml 0.9's createFromString(...), maybe
 
if it's not a good idea, just close this PR , thansks

possible usage:
```C++
std::string html = "........"
auto doc = litehtml::createFromString(html, container);
```
another:
possible usage:
```C++
auto doc = litehtml::createFromString(".......", container);
```