### PR TITLE
Fix flex item with percentage max-width collapsing below its main size (#459)

### DIFF
--- a/src/render_item.cpp
+++ b/src/render_item.cpp
@@ -1416,6 +1416,28 @@ litehtml::containing_block_context litehtml::render_item::calculate_containing_b
 		ret.max_height.value -= box_sizing_height();
 	}
 
+	// Issue #459: a flex item is rendered to its resolved main size via
+	// size_mode_exact_width. For a row-direction flex container the flex algorithm
+	// has already clamped the item's main size by its min/max-width, resolved
+	// against the flex container's width (see
+	// flex_item_row_direction::direction_specific_init). Re-applying a *percentage*
+	// min/max-width here would resolve it against the item's own exact size
+	// (cb_context.width == the assigned main size) instead of the container, and
+	// because the item is rendered more than once (flex_line::init, then
+	// align_stretch) the error compounds and the item collapses towards its content
+	// width. So skip the width clamp on that exact-width pass.
+	if (cb_context.size_mode & containing_block_context::size_mode_exact_width)
+	{
+		auto par = parent();
+		if (par && (par->css().get_display() == display_flex || par->css().get_display() == display_inline_flex)
+			&& (par->css().get_flex_direction() == flex_direction_row
+				|| par->css().get_flex_direction() == flex_direction_row_reverse))
+		{
+			ret.min_width.type = containing_block_context::cbc_value_type_none;
+			ret.max_width.type = containing_block_context::cbc_value_type_none;
+		}
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
Fixes #459.

### Problem
A flex item with a percentage `max-width` is laid out far narrower than its
flex-basis / resolved main size. For example, in a 600px row with two columns
`flex: 0 0 58.3333%; max-width: 58.3333%` and `flex: 0 0 41.6667%; max-width: 41.6667%`,
the items collapse to roughly their content width and pack at the start of the row
instead of filling it. This is the standard Bootstrap grid pattern
(`.col-* { flex: 0 0 X%; max-width: X% }`), so Bootstrap rows collapse.

### Cause
A row-direction flex item is rendered to its resolved main size via
`size_mode_exact_width`. The flex algorithm has already clamped that main size by
the item's min/max-width, resolved against the flex **container's** width
(`flex_item_row_direction::direction_specific_init`).

`render_item::calculate_containing_block_context` then re-applies the item's
min/max-width while rendering it at the exact main size. For a *percentage*
max-width this resolves against `cb_context.width`, which at this point equals the
assigned main size rather than the flex container width, so the item is clamped too
small. Because the item is rendered more than once (`flex_line::init`, then
`align_stretch`) the error compounds (e.g. 350 → 204 → 119 px) and the item
collapses toward its content width.

### Fix
Skip the min/max-width clamp for row-direction flex items on the `size_mode_exact_width`
pass, since the flex algorithm has already applied min/max-width against the
container. Non-flex items, column-direction items, and `px` max-width are unaffected.

### Testing
Verified with a QPainter-based container:
- `flex: 0 0 58.3333%; max-width: 58.3333%` in a 600px row → 350px (was ~119px).
- `px` max-width, no max-width, `flex: 1` grow → unchanged (still correct).
- A row item with `flex: 0 0 90%; max-width: 50%` still correctly clamps to 50%.
- A column-direction item with `max-width: 50%` still clamps its (cross) width.
- A real Bootstrap-based page now renders its grid side-by-side instead of collapsed.

Minimal reproduction and before/after screenshots are in #459.
