### PR TITLE
Rebuild the render tree in media_changed() so display changes across breakpoints take effect

### DIFF
--- a/src/document.cpp
+++ b/src/document.cpp
@@ -840,6 +840,17 @@ bool document::media_changed()
 	{
 		m_root->refresh_styles();
 		m_root->compute_styles();
+		// The set of rendered elements can change across a media breakpoint
+		// (e.g. display:none <-> block on responsive nav/hero blocks). The render
+		// tree is built once in createFromString() from the computed display values,
+		// so rebuild it here to add/remove render items for elements whose display
+		// just changed; otherwise a newly-shown element keeps no render item and
+		// never lays out (it collapses to zero).
+		m_root_render = m_root->create_render_item(nullptr);
+		if (m_root_render)
+		{
+			m_root_render = m_root_render->init();
+		}
 		return true;
 	}
 	return false;


### PR DESCRIPTION
### Summary
`document::media_changed()` recomputes element styles but does not rebuild the render
tree. As a result, an element that is `display: none` when the render tree is first
built and becomes `display: block` after a media change (a responsive breakpoint) never
gets a render item, so it stays invisible even though its computed `display` is now
`block`. Whole responsive sections (e.g. Bootstrap navbars/heroes that are hidden on
narrow viewports and shown on wide ones) disappear after the viewport crosses the
breakpoint.

### Reproduction
```html
<!DOCTYPE html>
<html><head><meta charset="utf-8"><style>
  .box { height: 60px; }
  /* hidden while the render tree is built (narrow), shown at >= 600px */
  .wide-only { display: none; background: #7ed07e; }
  @media (min-width: 600px) { .wide-only { display: block; } }
  .always { background: #7eb6e0; }
</style></head><body>
  <div class="box wide-only">WIDE-ONLY: must appear when width &gt;= 600px</div>
  <div class="box always">ALWAYS visible</div>
</body></html>
```

Steps:
1. Lay the document out with the container viewport **narrow** (`< 600px`). `.wide-only`
   is correctly `display: none`, so no render item is created for it.
2. Widen the viewport to `>= 600px`, call `document::media_changed()` and render again.

**Expected:** `.wide-only` becomes visible (green box above the blue one).

<img width="800" height="180" alt="image" src="https://github.com/user-attachments/assets/627da07e-fbba-402c-a912-807355f5b774" />

**Actual:** `.wide-only` stays missing; only `.always` (blue) is rendered.

<img width="800" height="180" alt="image" src="https://github.com/user-attachments/assets/17a34008-b203-4c05-b846-00ddfd852789" />


(Both screenshots below are rendered at width 800 — the only difference is the fix.)

### Root cause
The render tree (`m_root_render`) is created once in `createFromString()` via
`m_root->create_render_item(nullptr)` + `init()`, using the `display` values computed at
that moment. `media_changed()` then calls `refresh_styles()` + `compute_styles()`, which
update the computed `display` of the affected elements, but the render tree is left
as-is. So elements whose `display` toggled `none <-> block` across the breakpoint keep
(or keep lacking) their render items and never lay out.

### Fix
Rebuild the render tree at the end of `media_changed()` when the media actually changed:

```cpp
m_root->refresh_styles();
m_root->compute_styles();
m_root_render = m_root->create_render_item(nullptr);
if (m_root_render)
    m_root_render = m_root_render->init();
```

This runs only when `update_media_lists()` reports a change (i.e. when a breakpoint is
actually crossed), so it has no effect on ordinary re-renders/repaints — it mirrors what
`createFromString()` already does on initial layout.
