### PR TITLE
Support @layer, @supports, :where() and non-rendered pseudo-elements

### DIFF
--- a/include/litehtml/string_id.h
+++ b/include/litehtml/string_id.h
@@ -36,7 +36,7 @@ namespace litehtml
 
         // CSS pseudo-classes
         _root_, _only_child_, _only_of_type_, _first_child_, _first_of_type_, _last_child_, _last_of_type_, _nth_child_,
-        _nth_of_type_, _nth_last_child_, _nth_last_of_type_, _is_, _not_, _lang_,
+        _nth_of_type_, _nth_last_child_, _nth_last_of_type_, _is_, _where_, _not_, _lang_,
 
         _active_, _hover_,
 
@@ -102,8 +102,8 @@ namespace litehtml
         _repeating_radial_gradient_, _conic_gradient_, _repeating_conic_gradient_,
 
         // at-rules and their components
-        _charset_, _layer_, _import_, _media_, _and_, _or_, _boolean_, _plain_, _range_, _discrete_, _integer_,
-        _length_, _resolution_, _ratio_, _keyword_, _orientation_, _portrait_, _landscape_, _device_width_,
+        _charset_, _layer_, _supports_, _import_, _media_, _and_, _or_, _boolean_, _plain_, _range_, _discrete_,
+        _integer_, _length_, _resolution_, _ratio_, _keyword_, _orientation_, _portrait_, _landscape_, _device_width_,
         _device_height_, _aspect_ratio_, _device_aspect_ratio_, _color_index_, _monochrome_, )
 #undef STRING_ID
     extern const string_id empty_id; // _id("")

--- a/include/litehtml/style.h
+++ b/include/litehtml/style.h
@@ -60,6 +60,11 @@ namespace litehtml
 
         const property_value& get_property(string_id name) const;
 
+        bool empty() const
+        {
+            return m_properties.empty();
+        }
+
         void combine(const style& src);
         void clear()
         {

--- a/src/css_selector.cpp
+++ b/src/css_selector.cpp
@@ -717,6 +717,18 @@ namespace litehtml
         return ws ? ' ' : 0;
     }
 
+    bool has_pseudo_element(const css_element_selector& selector)
+    {
+        for(const auto& attr : selector.m_attrs)
+        {
+            if(attr.type == select_pseudo_element)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     css_selector::ptr parse_complex_selector(const css_token_vector& tokens, document_mode mode)
     {
         int index = 0;
@@ -742,6 +754,13 @@ namespace litehtml
                 return !combinator || combinator == ' ' ? selector : nullptr;
             }
             if(!combinator) // not the end and combinator failed to parse
+            {
+                return nullptr;
+            }
+
+            // "Only the last compound selector of a complex selector may contain a pseudo-element"
+            // https://www.w3.org/TR/selectors-4/#typedef-complex-selector
+            if(has_pseudo_element(selector->m_right))
             {
                 return nullptr;
             }

--- a/src/css_selector.cpp
+++ b/src/css_selector.cpp
@@ -16,6 +16,11 @@ namespace litehtml
         }
         for(const auto& attr : m_right.m_attrs)
         {
+            // :where() and its arguments add nothing  https://www.w3.org/TR/selectors-4/#zero-matches
+            if(attr.type == select_pseudo_class && attr.name == _where_)
+            {
+                continue;
+            }
             if(attr.type == select_id)
             {
                 m_specificity.b++;
@@ -418,7 +423,10 @@ namespace litehtml
         {
             return parse_nth_child(token, false, mode);
         }
-        if(name == "is") // https://www.w3.org/TR/selectors-4/#matches
+        // https://www.w3.org/TR/selectors-4/#matches
+        // https://www.w3.org/TR/selectors-4/#zero-matches
+        // :is() and :where() differ only in specificity, see css_selector::calc_specificity.
+        if(name == "is" || name == "where")
         {
             css_attribute_selector selector(select_pseudo_class, name);
             // "taking a <forgiving-selector-list> as its sole argument"
@@ -474,6 +482,11 @@ namespace litehtml
             "first-of-type",
             "last-of-type",
             "only-of-type",
+            // Shadow-tree pseudo-class  https://www.w3.org/TR/css-scoping-1/#host-selector
+            // Shadow trees are not implemented, so :host never matches, which is what a browser does
+            // for :host outside a shadow tree. Listed here so that a rule such as `:root, :host { ... }`
+            // keeps its other selectors instead of being dropped entirely.
+            "host",
         };
         return supported_simple_pseudo_classes.count(lowcase(name)) == 1;
     }
@@ -574,16 +587,21 @@ namespace litehtml
     }
 
     // simple = non-functional (without parentheses)
+    // Only ::before and ::after generate a box, see html_tag::select. The rest are parsed and never
+    // match, so that a rule like `.btn, ::file-selector-button { ... }` keeps its other selectors
+    // instead of being dropped because of one selector the engine cannot render.
     bool is_supported_simple_pseudo_element(const std::string& name)
     {
-        return is_one_of(lowcase(name),
-                         // Typographic Pseudo-elements  https://www.w3.org/TR/css-pseudo-4/#typographic-pseudos
-                         //"first-line", "first-letter",
-                         // Highlight Pseudo-elements  https://www.w3.org/TR/css-pseudo-4/#highlight-pseudos
-                         //"selection",
-                         // Tree-Abiding Pseudo-elements  https://www.w3.org/TR/css-pseudo-4/#treelike
-                         "before", "after" //"marker", "placeholder",
-        );
+        return is_one_of(
+            lowcase(name),
+            // Typographic Pseudo-elements  https://www.w3.org/TR/css-pseudo-4/#typographic-pseudos
+            "first-line", "first-letter",
+            // Highlight Pseudo-elements  https://www.w3.org/TR/css-pseudo-4/#highlight-pseudos
+            "selection",
+            // Tree-Abiding Pseudo-elements  https://www.w3.org/TR/css-pseudo-4/#treelike
+            "before", "after", "marker", "placeholder", "backdrop",
+            // https://html.spec.whatwg.org/multipage/rendering.html#the-file-selector-button-pseudo-element
+            "file-selector-button");
     }
 
     css_attribute_selector parse_pseudo_element(const css_token_vector& tokens, int& index)
@@ -603,7 +621,8 @@ namespace litehtml
 
         if(b.type == IDENT) // legacy syntax with one ':'  https://www.w3.org/TR/selectors-4/#single-colon-pseudos
         {
-            if(!is_one_of(b.ident(), "before", "after")) // first-line/letter are not supported
+            // only these four pseudo-elements may be written with a single colon
+            if(!is_one_of(b.ident(), "before", "after", "first-line", "first-letter"))
             {
                 return {};
             }

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -636,6 +636,7 @@ namespace litehtml
             }
             break;
         case _is_:
+        case _where_: // :where() matches like :is(), it only differs in specificity
             if(!select(sel.selector_list, true))
             {
                 return select_no_match;

--- a/src/stylesheet.cpp
+++ b/src/stylesheet.cpp
@@ -7,6 +7,129 @@
 namespace litehtml
 {
 
+    // ( <declaration> )  https://drafts.csswg.org/css-conditional-3/#typedef-supports-decl
+    static bool eval_supports_declaration(const css_token_vector& tokens, document_container* container)
+    {
+        // a <supports-decl> holds exactly one declaration
+        for(const auto& token : tokens)
+        {
+            if(token.ch == ';')
+            {
+                return false;
+            }
+        }
+        // the declaration is supported if litehtml was able to parse it
+        style st;
+        st.add(tokens, "", container);
+        return !st.empty();
+    }
+
+    // These return false when the syntax is invalid, which is not the same as a condition that is
+    // false: an @supports rule with an invalid condition is invalid and its block is never applied.
+    static bool parse_supports_condition(const css_token_vector& tokens, int& index, bool& result,
+                                         document_container* container);
+
+    // <supports-in-parens> = ( <supports-condition> ) | <supports-feature> | <general-enclosed>
+    static bool parse_supports_in_parens(const css_token& token, bool& result, document_container* container)
+    {
+        // <general-enclosed> = <function-token> <any-value>? )
+        // Any such function is unsupported, so it evaluates to false.
+        if(token.type == CV_FUNCTION)
+        {
+            result = false;
+            return true;
+        }
+        // everything but a block is not a <supports-in-parens> at all
+        if(token.type != ROUND_BLOCK)
+        {
+            return false;
+        }
+
+        // ( <supports-condition> )
+        int  index = 0;
+        bool value = false;
+        if(parse_supports_condition(token.value, index, value, container))
+        {
+            skip_whitespace(token.value, index);
+            if(index == static_cast<int>(token.value.size()))
+            {
+                result = value;
+                return true;
+            }
+        }
+        // ( <declaration> ), or <general-enclosed> = ( <any-value>? ) which evaluates to false
+        result = eval_supports_declaration(token.value, container);
+        return true;
+    }
+
+    // https://drafts.csswg.org/css-conditional-3/#typedef-supports-condition
+    // <supports-condition> = not <supports-in-parens>
+    //                      | <supports-in-parens> [ and <supports-in-parens> ]*
+    //                      | <supports-in-parens> [ or <supports-in-parens> ]*
+    static bool parse_supports_condition(const css_token_vector& tokens, int& index, bool& result,
+                                         document_container* container)
+    {
+        auto parse_operand = [&](bool& value) {
+            skip_whitespace(tokens, index);
+            if(!parse_supports_in_parens(at(tokens, index), value, container))
+            {
+                return false;
+            }
+            index++;
+            return true;
+        };
+        auto next_ident = [&]() {
+            skip_whitespace(tokens, index);
+            return lowcase(at(tokens, index).ident());
+        };
+
+        if(next_ident() == "not")
+        {
+            index++;
+            if(!parse_operand(result))
+            {
+                return false;
+            }
+            result = !result;
+            return true;
+        }
+
+        if(!parse_operand(result))
+        {
+            return false;
+        }
+
+        std::string op = next_ident();
+        if(op != "and" && op != "or")
+        {
+            return true; // a single <supports-in-parens>, the caller checks what follows it
+        }
+        // mixing `and` and `or` without parentheses is invalid, so the operator cannot change
+        while(next_ident() == op)
+        {
+            index++;
+            bool operand = false;
+            if(!parse_operand(operand))
+            {
+                return false;
+            }
+            result = op == "and" ? result && operand : result || operand;
+        }
+        return true;
+    }
+
+    static bool eval_supports_condition(const css_token_vector& tokens, document_container* container)
+    {
+        int  index  = 0;
+        bool result = false;
+        if(!parse_supports_condition(tokens, index, result, container))
+        {
+            return false;
+        }
+        skip_whitespace(tokens, index);
+        return index == static_cast<int>(tokens.size()) && result;
+    }
+
     // https://www.w3.org/TR/css-syntax-3/#parse-a-css-stylesheet
     template <class Input> // Input == string or css_token_vector
     void css::parse_css_stylesheet(const Input& input, const std::string& baseurl, const std::shared_ptr<document>& doc,
@@ -70,6 +193,39 @@ namespace litehtml
                     }
                     parse_css_stylesheet(rule->block.value, baseurl, doc, new_media, false);
                     import_allowed = false;
+                    break;
+                }
+
+            // https://drafts.csswg.org/css-conditional-3/#at-supports
+            // @supports <supports-condition> { <stylesheet> }
+            case _supports_:
+                {
+                    if(rule->block.type != CURLY_BLOCK)
+                    {
+                        break;
+                    }
+                    auto condition = normalize(rule->prelude, f_componentize);
+                    if(eval_supports_condition(condition, doc->container()))
+                    {
+                        parse_css_stylesheet(rule->block.value, baseurl, doc, media, false);
+                    }
+                    import_allowed = false;
+                    break;
+                }
+
+            // https://drafts.csswg.org/css-cascade-5/#at-layer
+            // @layer <layer-name># ;
+            // @layer <layer-name>? { <stylesheet> }
+            case _layer_:
+                {
+                    // Cascade layers are not implemented: a layer statement only declares layer order, so it
+                    // is ignored, and the rules of a layer block are used as if they were not layered.
+                    if(rule->block.type == CURLY_BLOCK)
+                    {
+                        parse_css_stylesheet(rule->block.value, baseurl, doc, media, false);
+                        import_allowed = false;
+                    }
+                    // a layer statement rule is allowed before @import and does not disallow it
                     break;
                 }
 


### PR DESCRIPTION
Rules that use CSS syntax litehtml doesn't implement are dropped together with everything standing next to them: an unrecognized at-rule takes its whole block, and an unrecognized pseudo-class or pseudo-element invalidates the entire selector list of the rule. Any current CSS toolchain hits this constantly.

On master:

| stylesheet | result |
| --- | --- |
| `@layer base { .a { color: red } }` | `.a` not styled |
| `@supports (display: flex) { .a { color: red } }` | `.a` not styled |
| `:where(.a) { color: red }` | `.a` not styled |
| `.a, ::file-selector-button { color: red }` | `.a` not styled |
| `:root, :host { --c: red }` | custom property never defined |

What this adds:

* `@layer` — a layer statement is ignored and the rules of a layer block are used as if they were not layered (cascade layers themselves are still not implemented).
* `@supports` — a condition is evaluated by parsing the declaration with the same code that parses a style block, so `(display: flex)` is true and `(display: grid)` is false, and a `not`/`and`/`or` fallback chain now selects the branch that can actually be rendered. `<general-enclosed>`, e.g. `selector(...)`, evaluates to false.
* `:where()` — matches like `:is()`, adds no specificity.
* `:host` and the pseudo-elements no box is generated for (`::first-line`, `::first-letter`, `::selection`, `::marker`, `::placeholder`, `::backdrop`, `::file-selector-button`) are parsed and never match, which is what they already do today when a rule uses them alone.

Stylesheets that don't use any of this parse exactly as before.

Happy to add render tests to litehtml-tests for these if you want them in the same round.
