### PR TITLE
Allow building a document from an externally created element tree

### DIFF
--- a/doc/using.md
+++ b/doc/using.md
@@ -23,6 +23,40 @@ static document::ptr  document::createFromString(
 
 Please refer to the [document::createFromString](document_createFromString.md) document for more details.
 
+## Building the element tree yourself
+
+If your application already has its own HTML tree (for example one built by another parser, or a UI
+tree that is not HTML at all), you can build the litehtml element tree directly instead of serializing
+it back to an HTML string for **createFromString** to parse again:
+
+```cpp
+auto doc = std::make_shared<litehtml::document>(container);
+// must be done before any element is created
+doc->set_document_mode(litehtml::no_quirks_mode);
+
+auto html = doc->create_element("html", {});
+auto body = doc->create_element("body", {});
+html->appendChild(body);
+
+auto div = doc->create_element("div", {{"class", "hello"}});
+body->appendChild(div);
+container->split_text("Hello world",
+    [&](const char* word)  { div->appendChild(std::make_shared<litehtml::el_text>(word, doc)); },
+    [&](const char* space) { div->appendChild(std::make_shared<litehtml::el_space>(space, doc)); });
+
+doc->finalize_from_external_root(html);
+```
+
+**finalize_from_external_root** takes the same ```master_styles``` and ```user_styles``` arguments as
+**createFromString** and performs the same finalization: it applies the stylesheets, computes the
+styles and builds the render tree. After that the document is used exactly like a parsed one
+(```render```, ```draw```, and so on).
+
+A document is finalized once, when its tree is complete - just like a parsed document is built once.
+Finalization accumulates state (parsed stylesheets, media lists, tabular elements, the render tree
+and the used selectors of every element), so a second call would duplicate it and is ignored. Build
+a new document if you need to rebuild.
+
 **createFromString** returns the ```litehtml::document``` pointer. Call ```litehtml::document::render(max_width)``` to render HTML elements:
 ```cpp
 m_doc->render(max_width);

--- a/include/litehtml/document.h
+++ b/include/litehtml/document.h
@@ -72,7 +72,8 @@ namespace litehtml
         std::string                             m_lang;
         std::string                             m_culture;
         std::string                             m_text;
-        document_mode                           m_mode = no_quirks_mode;
+        document_mode                           m_mode      = no_quirks_mode;
+        bool                                    m_finalized = false;
 
       public:
         document(document_container* objContainer);
@@ -132,6 +133,16 @@ namespace litehtml
         static document::ptr createFromString(const estring& str, document_container* container,
                                               const std::string& master_styles = litehtml::master_css,
                                               const std::string& user_styles   = {});
+
+        // The mode must be set before any element is created, because it is used in html_tag::set_attr.
+        void set_document_mode(document_mode mode);
+        // Finish a document whose element tree was built by the caller with create_element() and
+        // element::appendChild() instead of being parsed from an HTML string. Runs the same
+        // finalization sequence createFromString() runs after parsing. A document is finalized
+        // once, when its tree is complete; any further call does nothing.
+        void finalize_from_external_root(const std::shared_ptr<element>& root,
+                                         const std::string&              master_styles = litehtml::master_css,
+                                         const std::string&              user_styles   = {});
 
       private:
         uint_ptr add_font(const font_description& descr, font_metrics* fm);

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -74,82 +74,106 @@ namespace litehtml
         // Create litehtml::elements.
         elements_list root_elements;
         doc->create_node(output->root, root_elements, true, true);
+        element::ptr root;
         if(!root_elements.empty())
         {
-            doc->m_root = root_elements.back();
+            root = root_elements.back();
         }
 
         // Destroy GumboOutput
         gumbo_destroy_output(&kGumboDefaultOptions, output);
 
+        doc->finalize_from_external_root(root, master_styles, user_styles);
+
+        return doc;
+    }
+
+    void document::set_document_mode(document_mode mode)
+    {
+        m_mode = mode;
+    }
+
+    void document::finalize_from_external_root(const std::shared_ptr<element>& root, const std::string& master_styles,
+                                               const std::string& user_styles)
+    {
+        // Finalization accumulates state that is never rolled back: the parsed stylesheets, the media
+        // lists, the tabular elements, the render tree, and the used selectors of every element. A
+        // second run would duplicate all of it, so a document is finalized once, exactly like a parsed
+        // one. Build a new document to rebuild.
+        if(m_finalized)
+        {
+            return;
+        }
+        m_finalized = true;
+
+        m_root = root;
+
         if(master_styles != "")
         {
-            doc->m_master_css.parse_css_stylesheet(master_styles, "", doc);
-            doc->m_master_css.sort_selectors();
+            m_master_css.parse_css_stylesheet(master_styles, "", shared_from_this());
+            m_master_css.sort_selectors();
         }
         if(user_styles != "")
         {
-            doc->m_user_css.parse_css_stylesheet(user_styles, "", doc);
-            doc->m_user_css.sort_selectors();
+            m_user_css.parse_css_stylesheet(user_styles, "", shared_from_this());
+            m_user_css.sort_selectors();
         }
 
         // Let's process created elements tree
-        if(doc->m_root)
+        if(m_root)
         {
-            doc->container()->get_media_features(doc->m_media);
+            container()->get_media_features(m_media);
 
-            doc->m_root->set_pseudo_class(_root_, true);
+            m_root->set_pseudo_class(_root_, true);
 
             // apply master CSS
-            doc->m_root->apply_stylesheet(doc->m_master_css);
+            m_root->apply_stylesheet(m_master_css);
 
             // parse elements attributes
-            doc->m_root->parse_attributes();
+            m_root->parse_attributes();
 
             // parse style sheets linked in document
-            for(const auto& css : doc->m_css)
+            for(const auto& css : m_css)
             {
                 media_query_list_list::ptr media;
                 if(css.media != "")
                 {
-                    auto mq_list = parse_media_query_list(css.media, doc);
+                    auto mq_list = parse_media_query_list(css.media, shared_from_this());
                     media        = std::make_shared<media_query_list_list>();
                     media->add(mq_list);
                 }
-                doc->m_styles.parse_css_stylesheet(css.text, css.baseurl, doc, media);
+                m_styles.parse_css_stylesheet(css.text, css.baseurl, shared_from_this(), media);
             }
             // Sort css selectors using CSS rules.
-            doc->m_styles.sort_selectors();
+            m_styles.sort_selectors();
 
             // Apply media features.
-            doc->update_media_lists(doc->m_media);
+            update_media_lists(m_media);
 
             // Apply parsed styles.
-            doc->m_root->apply_stylesheet(doc->m_styles);
+            m_root->apply_stylesheet(m_styles);
 
             // Apply user styles if any
-            doc->m_root->apply_stylesheet(doc->m_user_css);
+            m_root->apply_stylesheet(m_user_css);
 
             // Initialize element::m_css
-            doc->m_root->compute_styles();
+            m_root->compute_styles();
 
             // Create rendering tree
-            doc->m_root_render = doc->m_root->create_render_item(nullptr);
+            m_root_render = m_root->create_render_item(nullptr);
 
             // Now the m_tabular_elements is filled with tabular elements.
             // We have to check the tabular elements for missing table elements
             // and create the anonymous boxes in visual table layout
-            doc->fix_tables_layout();
+            fix_tables_layout();
 
             // Finally initialize elements
             // init() returns pointer to the render_init element because it can change its type
-            if(doc->m_root_render)
+            if(m_root_render)
             {
-                doc->m_root_render = doc->m_root_render->init();
+                m_root_render = m_root_render->init();
             }
         }
-
-        return doc;
     }
 
     // https://html.spec.whatwg.org/multipage/parsing.html#change-the-encoding


### PR DESCRIPTION
A document can only be built by parsing an HTML string with gumbo. If the application already has its own tree — another HTML parser, or a UI tree that isn't HTML at all — it has to serialize that tree to HTML just so litehtml can parse it back, and there is no way to set the document mode for a tree litehtml did not parse itself.

This moves everything `createFromString` does *after* parsing into `document::finalize_from_external_root()`, so the same finalization (stylesheets, computed styles, render tree, table fixup) can be applied to a tree built with `create_element()` and `element::appendChild()`. `set_document_mode()` is added because the mode must be set before elements are created — `html_tag::set_attr()` uses it to lowercase `class` and `id` in quirks mode.

```cpp
auto doc = std::make_shared<litehtml::document>(container);
doc->set_document_mode(litehtml::no_quirks_mode);

auto html = doc->create_element("html", {});
auto body = doc->create_element("body", {});
html->appendChild(body);
// ... build the rest of the tree ...

doc->finalize_from_external_root(html);
doc->render(width);
```

`createFromString` now calls `finalize_from_external_root` and is otherwise unchanged, so parsed documents behave exactly as before.

Verified by building the tree for a small page by hand and comparing `document::dump()` plus the rendered size against the same page parsed from HTML — the output is byte-identical.

`doc/using.md` gets a short section describing the flow.

This is only about *building* a document; it is not incremental update — the tree is finalized once, exactly like a parsed one.
