### PR TITLE
Fix containing block of an absolutely positioned element's children

### DIFF
--- a/src/render_item.cpp
+++ b/src/render_item.cpp
@@ -752,8 +752,18 @@ void litehtml::render_item::render_positioned(render_type rt)
 
             if(need_render)
             {
+                // The width of the element is already resolved against its containing block, so it is
+                // passed as an exact width. Passing it as a normal containing block width would make
+                // the element resolve its own percentage width against itself, and its percentage
+                // sized children would then be laid out into that wrong containing block.
+                // An exact width is specified in the box sizing of the element, like the css width is,
+                // because calculate_containing_block_context() subtracts the paddings and the borders
+                // from it for a border-box element.
                 position pos = el->m_pos;
-                el->render(el->left(), el->top(), containing_block_size.new_width(el->width()), nullptr, true);
+                el->render(el->left(), el->top(),
+                           containing_block_size.new_width(el->m_pos.width + el->box_sizing_width(),
+                                                           containing_block_context::size_mode_exact_width),
+                           nullptr, true);
                 el->m_pos = pos;
             }
 


### PR DESCRIPTION
Percentage sized children of an absolutely or fixed positioned element are laid out into a containing block that is half of what it should be.

```html
<div style="position: relative; width: 400px">
  <div style="width: 100px">
    <div id="a" style="position: absolute; left: 0; width: 50%">
      <div id="b" style="width: 50%"></div>
    </div>
  </div>
</div>
```

`#a` is 200px, correct. `#b` is **50px**, it should be 100px.

The cause is in `render_item::render_positioned()`. When the width computed there differs from the width the element got in the normal flow pass, the element is rendered again, and that render is given the element's own width as its *containing block* width in normal size mode:

```cpp
el->render(el->left(), el->top(), containing_block_size.new_width(el->width()), nullptr, true);
```

`calculate_containing_block_context()` then resolves the element's own `width: 50%` against that, so the containing block handed to the children is half the element's width. The element itself keeps the right width only because `m_pos` is saved and restored around the call.

The trigger is any difference between the flow-pass width and the positioned width: an absolutely positioned element whose static parent is not its containing block (above), or any `position: fixed` element with a percentage width, since its containing block is the viewport.

The fix passes the already resolved width as an exact width, which is what the flex code does when it renders an item to a resolved main size. An exact width is specified in the box sizing of the element, like the css width is, so the paddings and the borders are added back for a border-box element.

Measured content box widths for a page covering the cases, against Chrome/Firefox:

| element | before | after | browsers |
| --- | --- | --- | --- |
| `position: absolute; width: 50%` in a narrower parent | 200 | 200 | 200 |
| its `width: 50%` child | **50** | 100 | 100 |
| its `width: 25%; padding: 0 10px` child | **25** | 50 | 50 |
| `position: fixed; width: 50%` | 500 | 500 | 500 |
| its `width: 50%` child | **125** | 250 | 250 |
| its `width: 25%; padding-left: 10%` child | **62** | 125 | 125 |
| `position: absolute; width: 50%` (parent is the containing block) | 200 | 200 | 200 |
| its `width: 50%` child | 100 | 100 | 100 |
| `position: absolute; width: 200px` and its `width: 50%` child | 200 / 100 | 200 / 100 | 200 / 100 |
| `position: absolute; left: 0; right: 100px` and its `width: 50%` child | 300 / 150 | 300 / 150 | 300 / 150 |
| `position: fixed; height: 20%` and its `height: 50%` child | 120 / 60 | 120 / 60 | 120 / 60 |

Percentage heights were already correct and stay correct - only the width was replaced in the containing block passed to the second render.

For regression I rendered every file of the render test suite with both revisions and compared the full render tree dump (positions included): all 92 files are identical.
