### PR TITLE
Fix box-sizing of an absolutely positioned element

### DIFF
--- a/src/render_item.cpp
+++ b/src/render_item.cpp
@@ -282,9 +282,11 @@ void litehtml::render_item::render_positioned(render_type rt)
             css_length el_width  = el->src_el()->css().get_width();
             css_length el_height = el->src_el()->css().get_height();
 
+            // The height is a css height, so it is specified in the box sizing of the element and
+            // the paddings and the borders are added to it only for a content-box element.
             auto fix_height_min_max = [&](pixel_t height) {
                 auto max_height = el->css().get_max_height();
-                auto min_height = el->css().get_max_height();
+                auto min_height = el->css().get_min_height();
                 if(!max_height.is_predefined())
                 {
                     pixel_t max_height_value = max_height.calc_percent(containing_block_size.height);
@@ -295,10 +297,11 @@ void litehtml::render_item::render_positioned(render_type rt)
                     pixel_t min_height_value = min_height.calc_percent(containing_block_size.height);
                     height                   = std::max(height, min_height_value);
                 }
-                height += el->content_offset_height();
+                height += el->content_offset_height() - el->box_sizing_height();
                 return height;
             };
 
+            // see fix_height_min_max
             auto fix_width_min_max = [&](pixel_t width) {
                 auto max_width = el->css().get_max_width();
                 auto min_width = el->css().get_min_width();
@@ -312,7 +315,7 @@ void litehtml::render_item::render_positioned(render_type rt)
                     pixel_t min_width_value = min_width.calc_percent(containing_block_size.width);
                     width                   = std::max(width, min_width_value);
                 }
-                width += el->content_offset_width();
+                width += el->content_offset_width() - el->box_sizing_width();
                 return width;
             };
 


### PR DESCRIPTION
`render_positioned()` adds the paddings and the borders to the css width and height of the element. For a border-box element they are already included, so an absolutely or fixed positioned element with `box-sizing: border-box` comes out too big by exactly that much.

`fix_height_min_max()` also reads `max-height` where it means `min-height`, so any height below `max-height` is raised up to it.

Content box sizes for elements positioned against a 1000x600 containing block, all with `box-sizing: border-box; border: 10px solid; padding: 5px` except the last one:

| declaration | before | after | browsers |
| --- | --- | --- | --- |
| `width: 50%` | 500 | 470 | 470 |
| `width: 300px` | 300 | 270 | 270 |
| `width: 50%; max-width: 300px` | 300 | 270 | 270 |
| `width: 10%; min-width: 400px` | 400 | 370 | 370 |
| `height: 20%` | 120 | 90 | 90 |
| `height: 5%; max-height: 60px` (content-box) | 60 | 30 | 30 |

Rendering every file of the render test suite with and without the change gives an identical render tree dump for all 92 files.
