### PR TITLE
Fix percentage bases of a positioned element

### DIFF
--- a/include/litehtml/types.h
+++ b/include/litehtml/types.h
@@ -351,6 +351,9 @@ namespace litehtml
             size_mode_exact_width  = 0x01,
             size_mode_exact_height = 0x02,
             size_mode_content      = 0x04,
+            // The element has already resolved its paddings, borders and margins against its containing
+            // block, and render() must not resolve them again against the width it is given.
+            size_mode_keep_outlines = 0x08,
         };
 
         struct typed_pixel

--- a/src/render_item.cpp
+++ b/src/render_item.cpp
@@ -31,7 +31,10 @@ litehtml::rendered_width litehtml::render_item::render(pixel_t x, pixel_t y,
                                                        const containing_block_context& containing_block_size,
                                                        formatting_context* fmt_ctx, bool second_pass)
 {
-    calc_outlines(containing_block_size.width);
+    if((containing_block_size.size_mode & containing_block_context::size_mode_keep_outlines) == 0)
+    {
+        calc_outlines(containing_block_size.width);
+    }
 
     m_pos.clear();
     m_pos.move_to(x, y);
@@ -757,17 +760,12 @@ void litehtml::render_item::render_positioned(render_type rt)
 
             if(need_render)
             {
-                position pos     = el->m_pos;
-                margins  padding = el->m_padding;
-                margins  borders = el->m_borders;
-                margins  margin  = el->m_margins;
-                el->render(el->left(), el->top(), containing_block_size.new_width(el->width()), nullptr, true);
-                // render() re-resolves the outlines against the width it is given, which here is the width of
-                // the element itself. Restore the values computed against the containing block.
-                el->m_pos     = pos;
-                el->m_padding = padding;
-                el->m_borders = borders;
-                el->m_margins = margin;
+                position pos = el->m_pos;
+                el->render(
+                    el->left(), el->top(),
+                    containing_block_size.new_width(el->width(), containing_block_context::size_mode_keep_outlines),
+                    nullptr, true);
+                el->m_pos = pos;
             }
 
             if(el_position == element_position_fixed)

--- a/src/render_item.cpp
+++ b/src/render_item.cpp
@@ -272,6 +272,11 @@ void litehtml::render_item::render_positioned(render_type rt)
                 containing_block_size.width  = m_pos.width + m_padding.width();
             }
 
+            // Percentage paddings, borders and margins resolve against the width of the containing block.
+            // The in-flow pass sized them against the parent the element was laid out in, which for a
+            // positioned element is not its containing block.
+            el->calc_outlines(containing_block_size.width);
+
             css_length css_left   = el->src_el()->css().get_offsets().left;
             css_length css_right  = el->src_el()->css().get_offsets().right;
             css_length css_top    = el->src_el()->css().get_offsets().top;
@@ -640,7 +645,7 @@ void litehtml::render_item::render_positioned(render_type rt)
                 }
                 if(!el->css().get_max_width().is_predefined())
                 {
-                    pixel_t max_width = el->css().get_max_width().calc_percent(containing_block_size.height);
+                    pixel_t max_width = el->css().get_max_width().calc_percent(containing_block_size.width);
                     if(width - el->content_offset_width() > max_width)
                     {
                         pixel_t reminded = width - el->content_offset_width() - max_width;
@@ -752,9 +757,17 @@ void litehtml::render_item::render_positioned(render_type rt)
 
             if(need_render)
             {
-                position pos = el->m_pos;
+                position pos     = el->m_pos;
+                margins  padding = el->m_padding;
+                margins  borders = el->m_borders;
+                margins  margin  = el->m_margins;
                 el->render(el->left(), el->top(), containing_block_size.new_width(el->width()), nullptr, true);
-                el->m_pos = pos;
+                // render() re-resolves the outlines against the width it is given, which here is the width of
+                // the element itself. Restore the values computed against the containing block.
+                el->m_pos     = pos;
+                el->m_padding = padding;
+                el->m_borders = borders;
+                el->m_margins = margin;
             }
 
             if(el_position == element_position_fixed)


### PR DESCRIPTION
Two percentage bases in `render_positioned()` are taken from the wrong box.

**Paddings, borders and margins.** They are resolved in `calc_outlines()` during the normal flow pass, against the width of the parent the element is laid out in. For a positioned element that parent is not its containing block:

```html
<div style="position: relative; width: 400px">
  <div style="width: 100px">
    <div style="position: absolute; padding: 0 10%"></div>
```

Padding comes out as 10% of 100px instead of 10% of 400px. For a fixed positioned element it is a percentage of whatever in-flow parent it happened to sit in, instead of the viewport.

`render_positioned()` now recomputes the outlines against the containing block. The second `render()` call must not undo that: it is given the width of the element itself, and would resolve the paddings against it, painting a border box wider than the element's own content box and starting at a negative x, and handing the children a containing block short by the difference. `render()` therefore skips `calc_outlines()` when the containing block carries the new `size_mode_keep_outlines`.

**max-width.** In the "`width` is auto, `left` and `right` are not auto" case a percentage `max-width` was resolved against the *height* of the containing block. `left:0; right:0; max-width:50%` in a 400x300 containing block gave 150px instead of 200px.

No test in litehtml-tests changes: I diffed the resolved geometry of every element over all 10057 files in the suite, before and after, and the output is identical. All the affected cases need the containing block to differ from the in-flow parent, which none of them currently do.
