### PR TITLE
Prune subtrees that miss the clip in draw_children (fixes #484)

### DIFF
--- a/include/litehtml/render_item.h
+++ b/include/litehtml/render_item.h
@@ -19,14 +19,18 @@ namespace litehtml
     class render_item : public std::enable_shared_from_this<render_item>
     {
       protected:
-        std::shared_ptr<element>                  m_element;
-        std::weak_ptr<render_item>                m_parent;
-        std::list<std::shared_ptr<render_item>>   m_children;
-        margins                                   m_margins;
-        margins                                   m_padding;
-        margins                                   m_borders;
-        position                                  m_pos;
-        bool                                      m_skip = false;
+        std::shared_ptr<element>                m_element;
+        std::weak_ptr<render_item>              m_parent;
+        std::list<std::shared_ptr<render_item>> m_children;
+        margins                                 m_margins;
+        margins                                 m_padding;
+        margins                                 m_borders;
+        position                                m_pos;
+        // Absolute document-space bounds for draw-time pruning, filled by
+        // calc_subtree_bounds after the final layout.
+        pixel_t                                   m_abs_top            = 0_px;
+        pixel_t                                   m_subtree_bottom_abs = 0_px;
+        bool                                      m_skip               = false;
         std::vector<std::shared_ptr<render_item>> m_positioned;
         std::shared_ptr<scroll_view>              m_scroll_view;
 
@@ -93,6 +97,18 @@ namespace litehtml
         position& pos()
         {
             return m_pos;
+        }
+
+        // Absolute (document-space) bounds for draw-time subtree pruning.
+        // calc_subtree_bounds must be called after the final layout.
+        void    calc_subtree_bounds(pixel_t abs_x, pixel_t abs_y);
+        pixel_t abs_top() const
+        {
+            return m_abs_top;
+        }
+        pixel_t subtree_bottom_abs() const
+        {
+            return m_subtree_bottom_abs;
         }
 
         // Calculates the position of the element in the document

--- a/include/litehtml/render_item.h
+++ b/include/litehtml/render_item.h
@@ -102,6 +102,7 @@ namespace litehtml
         // Absolute (document-space) bounds for draw-time subtree pruning.
         // calc_subtree_bounds must be called after the final layout.
         void    calc_subtree_bounds(pixel_t abs_x, pixel_t abs_y);
+        void    set_subtree_bounds(pixel_t abs_top, pixel_t subtree_bottom_abs);
         pixel_t abs_top() const
         {
             return m_abs_top;

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -558,6 +558,7 @@ namespace litehtml
                 m_size.width  = 0;
                 m_size.height = 0;
                 m_root_render->calc_document_size(m_size);
+                m_root_render->calc_subtree_bounds(0_px, 0_px);
             }
         }
         return ret;

--- a/src/render_item.cpp
+++ b/src/render_item.cpp
@@ -934,6 +934,23 @@ void litehtml::render_item::calc_subtree_bounds(pixel_t abs_x, pixel_t abs_y)
     m_abs_top            = abs_y + m_pos.top();
     m_subtree_bottom_abs = abs_y + m_pos.bottom() + m_margins.bottom + m_padding.bottom + m_borders.bottom;
 
+    // Same invariant as calc_document_size: all children of tables and of
+    // elements with overflow other than visible paint inside the element
+    // box. Their stored positions are not relative to this element (table
+    // rows and cells are positioned relative to the table), so accumulating
+    // offsets would place them wrong. Such descendants get this element's
+    // bounds instead: values that can only overstate their extent, which
+    // keeps the draw-time pruning from skipping visible content.
+    if(src_el()->css().get_display() == display_table ||
+       src_el()->css().get_overflow() != overflow_visible)
+    {
+        for(const auto& el : m_children)
+        {
+            el->set_subtree_bounds(m_abs_top, m_subtree_bottom_abs);
+        }
+        return;
+    }
+
     for(const auto& el : m_children)
     {
         el->calc_subtree_bounds(abs_x + m_pos.left(), abs_y + m_pos.top());
@@ -941,6 +958,16 @@ void litehtml::render_item::calc_subtree_bounds(pixel_t abs_x, pixel_t abs_y)
         {
             m_subtree_bottom_abs = el->m_subtree_bottom_abs;
         }
+    }
+}
+
+void litehtml::render_item::set_subtree_bounds(pixel_t abs_top, pixel_t subtree_bottom_abs)
+{
+    m_abs_top            = abs_top;
+    m_subtree_bottom_abs = subtree_bottom_abs;
+    for(const auto& el : m_children)
+    {
+        el->set_subtree_bounds(abs_top, subtree_bottom_abs);
     }
 }
 

--- a/src/render_item.cpp
+++ b/src/render_item.cpp
@@ -924,6 +924,26 @@ void litehtml::render_item::draw_stacking_context(uint_ptr hdc, pixel_t x, pixel
     }
 }
 
+// Compute absolute document-space bounds for this subtree: each item
+// stores the absolute top of its box and the absolute bottom of its
+// whole subtree (including margins and overflowing children). The
+// accumulation mirrors draw_children: a child's absolute position is
+// its m_pos plus the parent's absolute position.
+void litehtml::render_item::calc_subtree_bounds(pixel_t abs_x, pixel_t abs_y)
+{
+    m_abs_top            = abs_y + m_pos.top();
+    m_subtree_bottom_abs = abs_y + m_pos.bottom() + m_margins.bottom + m_padding.bottom + m_borders.bottom;
+
+    for(const auto& el : m_children)
+    {
+        el->calc_subtree_bounds(abs_x + m_pos.left(), abs_y + m_pos.top());
+        if(el->m_subtree_bottom_abs > m_subtree_bottom_abs)
+        {
+            m_subtree_bottom_abs = el->m_subtree_bottom_abs;
+        }
+    }
+}
+
 void litehtml::render_item::draw_children(uint_ptr hdc, pixel_t x, pixel_t y, const position* clip, draw_flag flag,
                                           int zindex)
 {
@@ -959,6 +979,24 @@ void litehtml::render_item::draw_children(uint_ptr hdc, pixel_t x, pixel_t y, co
     {
         if(el->is_visible())
         {
+            // Prune subtrees that cannot intersect the clip. In-flow
+            // children are in document order, so once a subtree starts
+            // below the clip the remaining ones are below too and the
+            // pass can stop. Fixed elements ignore the accumulated
+            // position, so they are never pruned this way.
+            if(clip)
+            {
+                bool fixed_el = el->src_el()->css().get_position() == element_position_fixed;
+                if(!fixed_el && el->subtree_bottom_abs() < clip->top())
+                {
+                    continue;
+                }
+                if((flag == draw_block || flag == draw_inlines || flag == draw_floats) && !fixed_el &&
+                   el->abs_top() > clip->bottom())
+                {
+                    break;
+                }
+            }
             bool process = true;
             switch(flag)
             {


### PR DESCRIPTION
## Problem

`document::draw` visits the entire element tree on every call. Paginated renderers (one draw call per page, each with a page-sized clip) therefore pay O(elements) per page — quadratic as documents grow. Profiled on a 227-page render: ~75% of CPU inside `render_item::draw_children` (#484 has the details and numbers).

## Fix

- `render_item::calc_subtree_bounds`: after layout, record each item's absolute top and the absolute bottom of its subtree (one extra walk; the offset accumulation mirrors what `draw_children` already does).
- `render_item::draw_children`: skip children whose subtree lies entirely above the clip, and — because in-flow children are in document order — stop the `draw_block`/`draw_inlines`/`draw_floats` passes at the first child that starts below the clip.
- `document::render`: runs the bounds walk once after layout.
- Fixed-position elements are exempt from pruning (they don't follow the accumulated position). No drawing logic is changed; the traversal just stops visiting subtrees that cannot intersect the clip.

## Verification

- markpdf (markdown → litehtml → libharu), 227-page novel render: **6.71 s → 1.20 s**; 696-page render: **53.5 s → 3.71 s**. Per-doubling scaling ratio went from ~3.2× to ~1.8×.
- Page counts unchanged (56 / 114 / 227 / 696 across test documents); sampled pages pixel-identical to the unpatched build (max pixel diff 0 at 72 dpi).
- The change is exercised continuously by markpdf's test suite (103 examples) and comparison documents (feature-probe kitchen sink, nested lists, tables, themes, images).

Happy to adjust naming/placement — e.g. if you'd rather compute the subtree bounds inside `render_item::render` instead of a separate post-layout walk.